### PR TITLE
ci: create cargo format, build and test github actions

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -1,0 +1,54 @@
+name: Cargo
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+  # By default, RUSTFLAGS with “-D warnings” turns “asm_const” warnings into errors.
+  RUSTFLAGS:
+
+jobs:
+  fmt:
+    name: Rustfmt all packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Rustfmt Check
+        uses: actions-rust-lang/rustfmt@v1
+  
+  test-bouffalo-hal:
+    name: Test
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PACKAGE: [bouffalo-hal, bouffalo-rt, blri]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Run tests
+        run: cargo test -p ${{ MATRIX.PACKAGE }}
+
+  build-bouffalo-hal:
+    name: Build
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        TARGET: [riscv64imac-unknown-none-elf]
+        TOOLCHAIN: [nightly]
+        EXAMPLES: [gpio-demo, i2c-demo, jtag-demo, lz4d-demo, pwm-demo, 
+          sdcard-demo, sdcard-gpt-demo, spi-demo, uart-demo]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ MATRIX.TARGET }}
+          toolchain: ${{ MATRIX.TOOLCHAIN }}
+      - name: Run build
+        run: cargo build --target ${{ MATRIX.TARGET }} --release -p ${{ MATRIX.EXAMPLES }}

--- a/bouffalo-rt/build.rs
+++ b/bouffalo-rt/build.rs
@@ -13,8 +13,16 @@ fn main() {
     #[cfg(feature = "bl702")]
     std::fs::write(ld, LINKER_SCRIPT_BL702).unwrap();
 
-    println!("cargo:rustc-link-arg=-T{}", ld.display());
-    println!("cargo:rustc-link-search={}", out.display());
+    #[cfg(any(
+        feature = "bl616",
+        feature = "bl808-mcu",
+        feature = "bl808-dsp",
+        feature = "bl702"
+    ))]
+    {
+        println!("cargo:rustc-link-arg=-T{}", ld.display());
+        println!("cargo:rustc-link-search={}", out.display());
+    }
 }
 
 #[cfg(feature = "bl616")]

--- a/examples/peripherals/lz4d-demo/src/main.rs
+++ b/examples/peripherals/lz4d-demo/src/main.rs
@@ -7,7 +7,7 @@ use core::pin::Pin;
 use embedded_time::rate::*;
 use panic_halt as _;
 
-static LZ4_INPUT: &[u8; 1182] = include_bytes!("text.lz4");
+static LZ4_INPUT: &'static [u8] = include_bytes!("text.lz4");
 static mut LZ4_OUTPUT: [u8; 2048] = [0u8; 2048];
 
 #[entry]


### PR DESCRIPTION
In this pr, GitHub Actions' behavior conforms to the definition of this script. There are three jobs `fmt`, `test-bouffalo-hal` and `build-bouffalo-hal`.

- `fmt`: format all packages on push and pull request.
- `test-bouffalo-hal`: test three main packages `bouffalo-hal`, `bouffalo-rt` and `blri` on push and pull request by using command `cargo test`.
- `build-bouffalo-hal`: build a series of examples, such as `gpio-demo`, `i2c-demo`, `jtag-demo`, `lz4d-demo`, `pwm-demo`, `sdcard-demo`, `sdcard-gpt-demo`, `spi-demo` and `uart-demo` by running the command `cargo build --target riscv64imac-unknown-none-elf --release -p xxx-demo`.

The GitHub Actions result are as follows:

![image](https://github.com/user-attachments/assets/787f28d6-21f9-4f57-82e9-7962657a46ac)

Moreover, fix the type mismatch for `static LZ4_INPUT` with `&'static [u8]` instead of `&[u8; 1182]` in the example lz4d-demo.

And to fix the error that `cannot find linker script /home/runner/work/bouffalo-hal/bouffalo-hal/target/debug/build/bouffalo-rt-e91e8eb23bb65c64/out/bouffalo-rt.ld` on the linux search the `bouffalo-rt.ld` when one of the feature `bl616`, `bl808-mcu`, `bl808-dsp` and `bl702` are used.  