### PR TITLE
examples: add cli support for uart-demo

### DIFF
--- a/examples/peripherals/uart-cli-demo/Cargo.toml
+++ b/examples/peripherals/uart-cli-demo/Cargo.toml
@@ -11,6 +11,7 @@ bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "0.2.0"
 embedded-time = "0.12.1"
+embedded-cli = "0.2.1"
 
 [[bin]]
 name = "uart-cli-demo"

--- a/examples/peripherals/uart-cli-demo/src/main.rs
+++ b/examples/peripherals/uart-cli-demo/src/main.rs
@@ -3,8 +3,30 @@
 
 use bouffalo_hal::prelude::*;
 use bouffalo_rt::{entry, Clocks, Peripherals};
+use embedded_cli::{cli::CliBuilder, Command};
 use embedded_time::rate::*;
 use panic_halt as _;
+
+#[derive(Command)]
+enum Base {
+    /// Print out 'Hello world!'.
+    Hello,
+    /// LED control command.
+    Led {
+        #[command(subcommand)]
+        command: Option<LedCommand>,
+    },
+}
+
+#[derive(Command)]
+enum LedCommand {
+    /// Turn on LED.
+    On,
+    /// Turn off LED.
+    Off,
+    /// Switch LED state.
+    Switch,
+}
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
@@ -20,13 +42,44 @@ fn main(p: Peripherals, c: Clocks) -> ! {
 
     let (mut tx, mut rx) = serial.split();
 
-    let mut buf = [0u8; 1];
+    let mut led = p.gpio.io8.into_floating_output();
+    let mut led_state = PinState::Low;
 
-    writeln!(tx, "Hello world!").ok();
-    rx.read_exact(&mut buf).ok();
-    writeln!(tx, "Character: {}", buf[0]).ok();
+    writeln!(tx, "Welcome to embedded-cli example by bouffalo-hal🦀!").ok();
+    writeln!(tx, "For command helps, type 'help'.").ok();
+
+    let (command_buffer, history_buffer) = ([0; 128], [0; 128]);
+    let mut cli = CliBuilder::default()
+        .writer(tx)
+        .command_buffer(command_buffer)
+        .history_buffer(history_buffer)
+        .prompt("uart-cli-demo> ")
+        .build()
+        .unwrap();
 
     loop {
-        // TODO: use embedded-cli to build a serial console
+        led.set_state(led_state).ok();
+        let mut slice = [0];
+        rx.read_exact(&mut slice).ok();
+        let _ = cli.process_byte::<Base, _>(
+            slice[0],
+            &mut Base::processor(|cli, command| {
+                match command {
+                    Base::Hello => {
+                        cli.writer().write_str("Hello world!").ok();
+                    }
+                    Base::Led { command } => match command {
+                        Some(LedCommand::On) => led_state = PinState::Low,
+                        Some(LedCommand::Off) => led_state = PinState::High,
+                        Some(LedCommand::Switch) => led_state = !led_state,
+                        None => match led_state {
+                            PinState::High => cli.writer().write_str("LED state: High").unwrap(),
+                            PinState::Low => cli.writer().write_str("LED state: Low").unwrap(),
+                        },
+                    },
+                }
+                Ok(())
+            }),
+        );
     }
 }


### PR DESCRIPTION
Add embedded-cli crate support for `uart-cli-demo`. Now, in addition to the original commands in `uart-demo`, `uart-cli-demo` features the command-line menu with autocomplete, history, and help command.

Ref: [embedded_cli](https://docs.rs/embedded-cli/latest/embedded_cli/), [Readme](https://github.com/funbiscuit/embedded-cli-rs/blob/main/README.md) and [Example](https://github.com/funbiscuit/embedded-cli-rs/blob/main/examples/arduino/src/main.rs).
