### PR TITLE
examples: fix broken spi related examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@
 | `jtag-demo`       | √     |
 | `lz4d-demo`       | √     |
 | `pwm-demo`        | √     |
-| `sdcard-demo`     | TODO   |
-| `sdcard-gpt-demo` | TODO   |
-| `spi-demo`        | X      |
+| `sdcard-demo`     | √     |
+| `sdcard-gpt-demo` | √     |
+| `spi-demo`        | √     |
 | `uart-demo`       | √     |

--- a/examples/peripherals/sdcard-demo/Cargo.toml
+++ b/examples/peripherals/sdcard-demo/Cargo.toml
@@ -12,9 +12,8 @@ bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "0.2.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
-riscv = "0.11.1"
-embedded-graphics = "0.8.1"
-embedded-sdmmc = "0.8.0"
+riscv = "0.10.1"
+embedded-sdmmc = "0.6.0"
 
 [[bin]]
 name = "sdcard-demo"

--- a/examples/peripherals/sdcard-demo/README.md
+++ b/examples/peripherals/sdcard-demo/README.md
@@ -6,3 +6,19 @@ Build this example with:
 rustup target install riscv64imac-unknown-none-elf
 cargo build --target riscv64imac-unknown-none-elf --release -p sdcard-demo
 ```
+
+If you are using the [Sipeed M1s Dock](https://wiki.sipeed.com/hardware/en/maix/m1s/m1s_dock.html) 
+development board, you may need to reconnect the corresponding pins according to the table below.
+
++-----+----------+-----------------------------------+------------------------------------+
+| pin | pin name | SD function(expected SD card pin) | SPI function(expected SD card pin) |
++-----+----------+-----------------------------------+------------------------------------+
+| 1   | io4      | DAT2(1)                           | X                                  |
+| 2   | io5      | DAT3(2)                           | X                                  |
+| 3   | io1      | CMD(3)                            | MOSI(3)                            |
+| 4   | VDD      | VDD(4)                            | VDD(4)                             |
+| 5   | io0      | CLK(5)                            | CS(2)                              |
+| 6   | GND      | VSS(6)                            | VSS(6)                             |
+| 7   | io2      | DAT0(7)                           | MISO(7)                            |
+| 8   | io3      | DAT1(8)                           | SCLK(5)                            |
++-----+----------+-----------------------------------+------------------------------------+

--- a/examples/peripherals/sdcard-gpt-demo/Cargo.toml
+++ b/examples/peripherals/sdcard-gpt-demo/Cargo.toml
@@ -12,9 +12,8 @@ bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "0.2.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
-riscv = "0.11.1"
-embedded-graphics = "0.8.1"
-embedded-sdmmc = "0.8.0"
+riscv = "0.10.1"
+embedded-sdmmc = "0.6.0"
 gpt_disk_io = "0.16.0"
 gpt_disk_types = "0.16.0"
 fatfs = { default-features = false, git = "https://github.com/rafalh/rust-fatfs" }

--- a/examples/peripherals/sdcard-gpt-demo/README.md
+++ b/examples/peripherals/sdcard-gpt-demo/README.md
@@ -8,3 +8,19 @@ Build this example with:
 rustup target install riscv64imac-unknown-none-elf
 cargo build --target riscv64imac-unknown-none-elf --release -p sdcard-gpt-demo
 ```
+
+If you are using the [Sipeed M1s Dock](https://wiki.sipeed.com/hardware/en/maix/m1s/m1s_dock.html) 
+development board, you may need to reconnect the corresponding pins according to the table below.
+
++-----+----------+-----------------------------------+------------------------------------+
+| pin | pin name | SD function(expected SD card pin) | SPI function(expected SD card pin) |
++-----+----------+-----------------------------------+------------------------------------+
+| 1   | io4      | DAT2(1)                           | X                                  |
+| 2   | io5      | DAT3(2)                           | X                                  |
+| 3   | io1      | CMD(3)                            | MOSI(3)                            |
+| 4   | VDD      | VDD(4)                            | VDD(4)                             |
+| 5   | io0      | CLK(5)                            | CS(2)                              |
+| 6   | GND      | VSS(6)                            | VSS(6)                             |
+| 7   | io2      | DAT0(7)                           | MISO(7)                            |
+| 8   | io3      | DAT1(8)                           | SCLK(5)                            |
++-----+----------+-----------------------------------+------------------------------------+

--- a/examples/peripherals/spi-demo/src/main.rs
+++ b/examples/peripherals/spi-demo/src/main.rs
@@ -27,7 +27,7 @@ fn main(p: Peripherals, _c: Clocks) -> ! {
     let lcd_dc = p.gpio.io13.into_floating_output();
     let mut lcd_bl = p.gpio.io11.into_floating_output();
     let lcd_rst = p.gpio.io24.into_floating_output();
-    let spi_lcd = Spi::new(p.spi0, (spi_clk, spi_mosi, spi_cs), MODE_0, &p.glb);
+    let spi_lcd = Spi::new(p.spi1, (spi_clk, spi_mosi, spi_cs), MODE_0, &p.glb);
 
     let mut delay = riscv::delay::McycleDelay::new(40_000_000);
     let di = display_interface_spi::SPIInterface::new(spi_lcd, lcd_dc);


### PR DESCRIPTION
fix broken spi related examples and update docs

- spi-demo
Change the spi device from spi0 to spi1, and it will run correctly. The running results are as follows:
![dfb988509ff180e60a5cdcb64eae78d0_720](https://github.com/user-attachments/assets/1a1f2c17-009f-4692-b22a-4147a34760c4)

- sdcard-demo and sdcard-gpt-demo
Changing the version of the dependency embedded-sdmmc to 0.6.0, the two demos can run normally. The reason why the 0.8.0 version cannot run normally is still being investigated. In addition, the requirements for pins have been added to README. The running results are as follows:

![e7a8f00dcd3a3b04c04950a7cff533a6](https://github.com/user-attachments/assets/bc4b747c-dc3a-47ac-b449-c5de59302275)
![8113ac26537082aed69f3c35a3f56a6a](https://github.com/user-attachments/assets/63f9d51e-8584-4494-bf6d-57da4f0d987e)
