### PR TITLE
docs(examples): add flash tutorials to spi related examples

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+blri = "run --package blri --release --"

--- a/examples/peripherals/sdcard-demo/README.md
+++ b/examples/peripherals/sdcard-demo/README.md
@@ -22,3 +22,32 @@ development board, you may need to reconnect the corresponding pins according to
 | 7   | io2      | DAT0(7)                           | MISO(7)                            |
 | 8   | io3      | DAT1(8)                           | SCLK(5)                            |
 +-----+----------+-----------------------------------+------------------------------------+
+
+Objcopy and prepare flash image with:
+
+```
+cargo install cargo-binutils
+rustup component add llvm-tools-preview
+rust-objcopy --binary-architecture=riscv64 --strip-all -O binary ./target/riscv64imac-unknown-none-elf/release/sdcard-demo ./target/riscv64imac-unknown-none-elf/release/sdcard-demo.bin
+cargo blri ./target/riscv64imac-unknown-none-elf/release/sdcard-demo.bin
+```
+
+Flash the binary file to the board with [Bouffalo Lab Dev Cube](https://dev.bouffalolab.com/download) on Windows:
+
+1. Connect the board to the computer via UART (Here takes M1s Dock as an example):
+    - Normally, you can see 2 new serial ports. If not, visit [Burn onboard bl702](https://wiki.sipeed.com/hardware/en/maix/m1s/other/start.html#Burn-onboard-bl702) for help.
+  
+2. Run the `BLDevCube.exe`, choose `BL808`, and click `Finish`.
+   
+3. In MCU page, browse `target\riscv64imac-unknown-none-elf\release\sdcard-demo.bin` as the target of `D0 Group`. Choose the bigger number serial port, and set uart rate 2000000.
+
+4. Press BOOT and RST on the board, then release RST first and BOOT after to be into UART burning mode.
+
+5. Click `Create & Download`, wait for flash the binary file to success.
+
+6. After flashing, repower the board and open the serial port to see the output like this:
+
+```
+Hello world!
+Card size: 7822376960
+```

--- a/examples/peripherals/sdcard-gpt-demo/README.md
+++ b/examples/peripherals/sdcard-gpt-demo/README.md
@@ -24,3 +24,33 @@ development board, you may need to reconnect the corresponding pins according to
 | 7   | io2      | DAT0(7)                           | MISO(7)                            |
 | 8   | io3      | DAT1(8)                           | SCLK(5)                            |
 +-----+----------+-----------------------------------+------------------------------------+
+
+Objcopy and prepare flash image with:
+
+```
+cargo install cargo-binutils
+rustup component add llvm-tools-preview
+rust-objcopy --binary-architecture=riscv64 --strip-all -O binary ./target/riscv64imac-unknown-none-elf/release/sdcard-gpt-demo ./target/riscv64imac-unknown-none-elf/release/sdcard-gpt-demo.bin
+cargo blri ./target/riscv64imac-unknown-none-elf/release/sdcard-gpt-demo.bin
+```
+
+Flash the binary file to the board with [Bouffalo Lab Dev Cube](https://dev.bouffalolab.com/download) on Windows:
+
+1. Connect the board to the computer via UART (Here takes M1s Dock as an example):
+    - Normally, you can see 2 new serial ports. If not, visit [Burn onboard bl702](https://wiki.sipeed.com/hardware/en/maix/m1s/other/start.html#Burn-onboard-bl702) for help.
+  
+2. Run the `BLDevCube.exe`, choose `BL808`, and click `Finish`.
+   
+3. In MCU page, browse `target\riscv64imac-unknown-none-elf\release\sdcard-gpt-demo.bin` as the target of `D0 Group`. Choose the bigger number serial port, and set uart rate 2000000.
+
+4. Press BOOT and RST on the board, then release RST first and BOOT after to be into UART burning mode.
+
+5. Click `Create & Download`, wait for flash the binary file to success.
+
+6. After flashing, repower the board and open the serial port to see the output like this:
+
+```
+Hello world!
+Card size: 7822376960
+Primary header: GptHeader { signature: GptHeaderSignature(16933534594248999176), revision: GptHeaderRevision(3942645758), header_size: 3942645758, header_crc32: Crc32(3942645758), reserved: 3942645758, my_lba: LbaLe(16933534594265776126), alternate_lba: LbaLe(0), first_usable_lba: LbaLe(0), last_usable_lba: LbaLe(0), disk_guid: Guid { time_low: 0, time_mid: [0, 0], time_high_and_version: [0, 0], clock_seq_high_and_reserved: 0, clock_seq_low: 2, node: [1, 0, 84, 84, 0, 0] }, partition_entry_lba: LbaLe(18446462603027742720), number_of_partition_entries: 0, size_of_partition_entry: 50331648, partition_entry_array_crc32: Crc32(26508785) }
+```

--- a/examples/peripherals/spi-demo/README.md
+++ b/examples/peripherals/spi-demo/README.md
@@ -14,6 +14,23 @@ cargo build --target riscv64imac-unknown-none-elf --release -p spi-demo
 Objcopy and prepare flash image with:
 
 ```
+cargo install cargo-binutils
+rustup component add llvm-tools-preview
 rust-objcopy --binary-architecture=riscv64 --strip-all -O binary ./target/riscv64imac-unknown-none-elf/release/spi-demo ./target/riscv64imac-unknown-none-elf/release/spi-demo.bin
-blri ./target/riscv64imac-unknown-none-elf/release/spi-demo.bin
+cargo blri ./target/riscv64imac-unknown-none-elf/release/spi-demo.bin
 ```
+
+Flash the binary file to the board with [Bouffalo Lab Dev Cube](https://dev.bouffalolab.com/download) on Windows:
+
+1. Connect the board to the computer via UART (Here takes M1s Dock as an example):
+    - Normally, you can see 2 new serial ports. If not, visit [Burn onboard bl702](https://wiki.sipeed.com/hardware/en/maix/m1s/other/start.html#Burn-onboard-bl702) for help.
+  
+2. Run the `BLDevCube.exe`, choose `BL808`, and click `Finish`.
+   
+3. In MCU page, browse `target\riscv64imac-unknown-none-elf\release\spi-demo.bin` as the target of `D0 Group`. Choose the bigger number serial port, and set uart rate 2000000.
+
+4. Press BOOT and RST on the board, then release RST first and BOOT after to be into UART burning mode.
+
+5. Click `Create & Download`, wait for flash the binary file to success.
+
+6. After flashing, repower the board and you will see the `ferris` image on the screen.


### PR DESCRIPTION
- add flash tutorials to `spi-demo`, `sdcard-demo`, `sdcard-gpt-demo`
- add `blri` command, use `blri` by `cargo blri <file_path>`