### PR TITLE
spi: implement SpiBus and SpiDevice trait, update dependencies

### DIFF
--- a/examples/peripherals/sdcard-demo/Cargo.toml
+++ b/examples/peripherals/sdcard-demo/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 [dependencies]
 bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
-panic-halt = "0.2.0"
+panic-halt = "1.0.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
-riscv = "0.10.1"
-embedded-sdmmc = "0.6.0"
+riscv = "0.12.1"
+embedded-sdmmc = "0.8.1"
 
 [[bin]]
 name = "sdcard-demo"

--- a/examples/peripherals/sdcard-gpt-demo/Cargo.toml
+++ b/examples/peripherals/sdcard-gpt-demo/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 [dependencies]
 bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
-panic-halt = "0.2.0"
+panic-halt = "1.0.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
-riscv = "0.10.1"
-embedded-sdmmc = "0.6.0"
+riscv = "0.12.1"
+embedded-sdmmc = "0.8.1"
 gpt_disk_io = "0.16.0"
 gpt_disk_types = "0.16.0"
 fatfs = { default-features = false, git = "https://github.com/rafalh/rust-fatfs" }


### PR DESCRIPTION
In previous development, we discovered that after updating the `embedded-sdmmc` version, the related examples could not run properly. At that time, we make a temporary fix by using an older version (https://github.com/rustsbi/bouffalo-hal/pull/6). 

Recently, I spent some time investigating the issue and found that it was due to the `embedded-sdmmc` using `SpiDevice` in the new version of the `embedded-hal`. Most operations on SPI were performed using the `Transfer` operation within the `transaction` function, which we had not implemented, leading to a panic.

![image](https://github.com/user-attachments/assets/4300a76b-5f85-4c6d-935a-8e71e06f5353)

In the older version of `embedded-hal`, the `SpiDevice` trait was not provided, and related operations were completed directly through functions like `transfer`. As a result, even if some functions were not implemented, they could still run normally.

![image](https://github.com/user-attachments/assets/ef0efe7e-f8bd-4190-ab25-e5d7a1083de4)


Therefore, in this pull request, I have implemented all the functions of the `SpiDevice` and `SpiBus` traits and updated the `embedded-sdmmc` and other dependencies to their latest versions. Now, they can run properly.

![image](https://github.com/user-attachments/assets/268ffea2-77be-453d-aff9-3d2e353a99e2)
