### PR TITLE
i2c: add `max_retry` to i2c read and fix i2c-demo

### DIFF
--- a/examples/peripherals/i2c-demo/src/main.rs
+++ b/examples/peripherals/i2c-demo/src/main.rs
@@ -21,12 +21,18 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
     let mut led = p.gpio.io8.into_floating_output();
 
-    let scl = p.gpio.io6.into_i2c::<2>();
-    let sda = p.gpio.io7.into_i2c::<2>();
+    let scl = p.gpio.io6.into_i2c::<0>();
+    let sda = p.gpio.io7.into_i2c::<0>();
     let mut i2c = I2c::new(p.i2c0, (scl, sda), &p.glb);
     i2c.enable_sub_address(SCREEN_TOUCH_SUB_ADDRESS);
 
     writeln!(serial, "Hello Rust🦀!").ok();
+    writeln!(
+        serial,
+        "Welcome to I2C demo, touch the screen to turn on the LED"
+    )
+    .ok();
+    led.set_high().ok();
     let mut buf = [0u8; 6];
     loop {
         riscv::asm::delay(100_000);
@@ -39,9 +45,7 @@ fn main(p: Peripherals, c: Clocks) -> ! {
                 }
                 writeln!(serial, "pos: ({}, {})[{}]", buf[3], buf[5], buf[2] >> 4).ok();
             }
-            Err(_) => {
-                led.set_high().ok();
-            }
+            Err(_) => {}
         }
     }
 }


### PR DESCRIPTION
Tested on my m1s dock board:

![438a8a6fcd5e4ca2ad57b4775fe081fc](https://github.com/user-attachments/assets/da4bf47b-d24c-4aeb-ad34-29ba52200eb6)
