### PR TITLE
build(deps): upgrade dependencies

### DIFF
--- a/examples/peripherals/uart-async-demo/Cargo.toml
+++ b/examples/peripherals/uart-async-demo/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 [dependencies]
 bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
-panic-halt = "0.2.0"
+panic-halt = "1.0.0"
 embedded-time = "0.12.1"
-riscv = "0.11.1"
+riscv = "0.12.1"
 
 [[bin]]
 name = "uart-async-demo"


### PR DESCRIPTION
Upgraded `panic-halt` and `riscv` dependencies to their latest versions.