### PR TITLE
psram: fix read and write errors on some boards

### DIFF
--- a/bouffalo-hal/src/psram.rs
+++ b/bouffalo-hal/src/psram.rs
@@ -1,5 +1,7 @@
 //! Pseudo Static Random Access Memory.
 
+use core::ptr;
+
 use crate::glb;
 use volatile_register::RW;
 
@@ -48,6 +50,8 @@ pub fn init_psram(psram: &RegisterBlock, glb: &glb::v2::RegisterBlock) {
         psram.phy_config[18].write(0x00208A08);
         psram.phy_config[19].write(0x00000000);
         psram.phy_config[20].write(0x01334433);
+
+        ptr::write_volatile(0x200007E8 as *mut u32, 0x32000); // TODO: fix magic and hardcode
     }
 }
 


### PR DESCRIPTION
Recently, we found that some development boards had read and write errors in psram-demo. In this PR, we fixed this problem by comparing the values ​​of the registers with the official code.

Additionally, the psram initialization code is still mainly hard-coded. In the future, we will try to analyze it further for a deeper understanding.

Tested on my two M1s Dock development boards:

![image](https://github.com/user-attachments/assets/27c28ce1-4687-441e-8ca2-a615b4268435)
