### PR TITLE
Add DMA support for UART peripheral and a new `uart-dma-demo` example

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -44,7 +44,7 @@ jobs:
         TARGET: [riscv64imac-unknown-none-elf]
         TOOLCHAIN: [nightly]
         EXAMPLES: [gpio-demo, i2c-demo, jtag-demo, lz4d-demo, pwm-demo, 
-          sdcard-demo, sdcard-gpt-demo, spi-demo, uart-demo, uart-async-demo, uart-cli-demo]
+          sdcard-demo, sdcard-gpt-demo, spi-demo, uart-demo, uart-async-demo, uart-cli-demo, uart-dma-demo]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "examples/peripherals/uart-demo",
     "examples/peripherals/uart-async-demo",
     "examples/peripherals/uart-cli-demo",
+    "examples/peripherals/uart-dma-demo",
     "examples/peripherals/sdcard-demo",
     "examples/peripherals/sdcard-gpt-demo",
     "examples/peripherals/psram-demo",

--- a/bouffalo-hal/src/dma.rs
+++ b/bouffalo-hal/src/dma.rs
@@ -1,6 +1,10 @@
 //! Direct Memory Access peripheral.
 
+use core::ops::Deref;
+
 use volatile_register::{RO, RW, WO};
+
+use crate::glb;
 
 /// Direct Memory Access peripheral registers.
 #[repr(C)]
@@ -162,7 +166,7 @@ pub enum EndianMode {
 
 impl GlobalConfig {
     const AHB_MASTER_ENDIAN_CFG: u32 = 0x1 << 1;
-    const SMDMA: u32 = 0x1;
+    const DMA: u32 = 0x1;
 
     /// Set AHB master endian mode.
     #[inline]
@@ -180,20 +184,20 @@ impl GlobalConfig {
             _ => EndianMode::BigEndian,
         }
     }
-    /// Enable SMDMA.
+    /// Enable DMA.
     #[inline]
-    pub const fn enable_smdma(self) -> Self {
-        Self((self.0 & !Self::SMDMA) | 1)
+    pub const fn enable_dma(self) -> Self {
+        Self((self.0 & !Self::DMA) | 1)
     }
-    /// Disable SMDMA.
+    /// Disable DMA.
     #[inline]
-    pub const fn disable_smdma(self) -> Self {
-        Self((self.0 & !Self::SMDMA) | 0)
+    pub const fn disable_dma(self) -> Self {
+        Self((self.0 & !Self::DMA) | 0)
     }
-    /// Check if SMDMA is enabled.
+    /// Check if DMA is enabled.
     #[inline]
-    pub const fn is_smdma_enabled(self) -> bool {
-        (self.0 & Self::SMDMA) != 0
+    pub const fn is_dma_enabled(self) -> bool {
+        (self.0 & Self::DMA) != 0
     }
 }
 
@@ -214,16 +218,41 @@ pub struct ChannelRegisters {
 }
 
 /// Linked list item pool descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(C)]
-pub struct LliItemPool {
+pub struct LliPool {
     /// Source address.
-    pub source_address: u32,
+    pub src_addr: u32,
     /// Destination address.
-    pub destination_address: u32,
+    pub dst_addr: u32,
     /// Physical address to next linked list item.
-    pub linked_list_item: u32,
+    pub next_lli: u32,
     /// Linked list item control register.
     pub control: LliControl,
+}
+
+impl LliPool {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            src_addr: 0,
+            dst_addr: 0,
+            next_lli: 0,
+            control: LliControl(0),
+        }
+    }
+}
+
+/// Linked list item transfer descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(C)]
+pub struct LliTransfer {
+    /// Source address.
+    pub src_addr: u32,
+    /// Destination address.
+    pub dst_addr: u32,
+    /// How many bytes should be transferred.
+    pub nbytes: u32,
 }
 
 /// Control register in linked list item.
@@ -430,8 +459,9 @@ impl LliControl {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ChannelConfig(u32);
 
+/// DMA transfer mode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum DMAMode {
+pub enum DmaMode {
     /// Memory to memory (DMA).
     Mem2Mem,
     /// Peripheral to memory (DMA).
@@ -452,7 +482,7 @@ pub enum DMAMode {
 
 /// Peripheral for DMA 0/1.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum Periph4DMA01 {
+pub enum Periph4Dma01 {
     /// UART0 receive.
     Uart0Rx,
     /// UART0 transmit.
@@ -499,7 +529,7 @@ pub enum Periph4DMA01 {
 
 /// Peripheral for DMA 2.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum Periph4DMA2 {
+pub enum Periph4Dma2 {
     /// UART3 receive.
     Uart3Rx,
     /// UART3 transmit.
@@ -522,6 +552,17 @@ pub enum Periph4DMA2 {
     DsiTx,
     /// DBI receive.
     DbiTx = 22,
+}
+
+/// DMA peripheral request definition
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DmaPeriphReq {
+    /// Dma request for peripheral for DMA 0/1.
+    Dma01(Periph4Dma01),
+    /// Dma request for peripheral for DMA 2.
+    Dma2(Periph4Dma2),
+    /// No dma request.
+    None,
 }
 
 impl ChannelConfig {
@@ -608,132 +649,132 @@ impl ChannelConfig {
     }
     /// Set DMA mode.
     #[inline]
-    pub const fn set_dma_mode(self, mode: DMAMode) -> Self {
+    pub const fn set_dma_mode(self, mode: DmaMode) -> Self {
         Self((self.0 & !Self::FLW_CTRL) | ((mode as u32) << 11))
     }
     /// Get DMA mode.
     #[inline]
-    pub const fn dma_mode(self) -> DMAMode {
+    pub const fn dma_mode(self) -> DmaMode {
         match ((self.0 & Self::FLW_CTRL) >> 11) as u8 {
-            0 => DMAMode::Mem2Mem,
-            1 => DMAMode::Mem2Periph,
-            2 => DMAMode::Periph2Mem,
-            3 => DMAMode::Periph2Periph,
-            4 => DMAMode::Periph2PeriphCtrlByDst,
-            5 => DMAMode::Mem2PeriphCtrlByPeriph,
-            6 => DMAMode::Periph2MemCtrlByPeriph,
-            _ => DMAMode::Periph2PeriphCtrlBySrc,
+            0 => DmaMode::Mem2Mem,
+            1 => DmaMode::Mem2Periph,
+            2 => DmaMode::Periph2Mem,
+            3 => DmaMode::Periph2Periph,
+            4 => DmaMode::Periph2PeriphCtrlByDst,
+            5 => DmaMode::Mem2PeriphCtrlByPeriph,
+            6 => DmaMode::Periph2MemCtrlByPeriph,
+            _ => DmaMode::Periph2PeriphCtrlBySrc,
         }
     }
     /// Set destination peripheral for DMA 0/1.
     #[inline]
-    pub const fn set_dst_periph4dma01(self, periph: Periph4DMA01) -> Self {
+    pub const fn set_dst_periph4dma01(self, periph: Periph4Dma01) -> Self {
         Self((self.0 & !Self::DST_PERIPH) | (Self::DST_PERIPH & ((periph as u32) << 6)))
     }
     /// Set destination peripheral for DMA2.
     #[inline]
-    pub const fn set_dst_periph4dma2(self, periph: Periph4DMA2) -> Self {
+    pub const fn set_dst_periph4dma2(self, periph: Periph4Dma2) -> Self {
         Self((self.0 & !Self::DST_PERIPH) | (Self::DST_PERIPH & ((periph as u32) << 6)))
     }
     /// Get destination peripheral for DMA 0/1.
     #[inline]
-    pub const fn dst_periph4dma01(self) -> Periph4DMA01 {
+    pub const fn dst_periph4dma01(self) -> Periph4Dma01 {
         match ((self.0 & Self::DST_PERIPH) >> 6) as u8 {
-            0 => Periph4DMA01::Uart0Rx,
-            1 => Periph4DMA01::Uart0Tx,
-            2 => Periph4DMA01::Uart1Rx,
-            3 => Periph4DMA01::Uart1Tx,
-            4 => Periph4DMA01::Uart2Rx,
-            5 => Periph4DMA01::Uart2Tx,
-            6 => Periph4DMA01::I2c0Rx,
-            7 => Periph4DMA01::I2c0Tx,
-            8 => Periph4DMA01::IrTx,
-            9 => Periph4DMA01::GpioTx,
-            10 => Periph4DMA01::Spi0Rx,
-            11 => Periph4DMA01::Spi0Tx,
-            12 => Periph4DMA01::AudioRx,
-            13 => Periph4DMA01::AudioTx,
-            14 => Periph4DMA01::I2c1Rx,
-            15 => Periph4DMA01::I2c1Tx,
-            16 => Periph4DMA01::I2sRx,
-            17 => Periph4DMA01::I2sTx,
-            18 => Periph4DMA01::PdmRx,
-            22 => Periph4DMA01::GpAdc,
-            23 => Periph4DMA01::GpDac,
+            0 => Periph4Dma01::Uart0Rx,
+            1 => Periph4Dma01::Uart0Tx,
+            2 => Periph4Dma01::Uart1Rx,
+            3 => Periph4Dma01::Uart1Tx,
+            4 => Periph4Dma01::Uart2Rx,
+            5 => Periph4Dma01::Uart2Tx,
+            6 => Periph4Dma01::I2c0Rx,
+            7 => Periph4Dma01::I2c0Tx,
+            8 => Periph4Dma01::IrTx,
+            9 => Periph4Dma01::GpioTx,
+            10 => Periph4Dma01::Spi0Rx,
+            11 => Periph4Dma01::Spi0Tx,
+            12 => Periph4Dma01::AudioRx,
+            13 => Periph4Dma01::AudioTx,
+            14 => Periph4Dma01::I2c1Rx,
+            15 => Periph4Dma01::I2c1Tx,
+            16 => Periph4Dma01::I2sRx,
+            17 => Periph4Dma01::I2sTx,
+            18 => Periph4Dma01::PdmRx,
+            22 => Periph4Dma01::GpAdc,
+            23 => Periph4Dma01::GpDac,
             _ => unreachable!(),
         }
     }
     /// Get destination peripheral for DMA2.
     #[inline]
-    pub const fn dst_periph4dma2(self) -> Periph4DMA2 {
+    pub const fn dst_periph4dma2(self) -> Periph4Dma2 {
         match ((self.0 & Self::DST_PERIPH) >> 6) as u8 {
-            0 => Periph4DMA2::Uart3Rx,
-            1 => Periph4DMA2::Uart3Tx,
-            2 => Periph4DMA2::Spi1Rx,
-            3 => Periph4DMA2::Spi1Tx,
-            6 => Periph4DMA2::I2c2Rx,
-            7 => Periph4DMA2::I2c2Tx,
-            8 => Periph4DMA2::I2c3Rx,
-            9 => Periph4DMA2::I2c3Tx,
-            10 => Periph4DMA2::DsiRx,
-            11 => Periph4DMA2::DsiTx,
-            22 => Periph4DMA2::DbiTx,
+            0 => Periph4Dma2::Uart3Rx,
+            1 => Periph4Dma2::Uart3Tx,
+            2 => Periph4Dma2::Spi1Rx,
+            3 => Periph4Dma2::Spi1Tx,
+            6 => Periph4Dma2::I2c2Rx,
+            7 => Periph4Dma2::I2c2Tx,
+            8 => Periph4Dma2::I2c3Rx,
+            9 => Periph4Dma2::I2c3Tx,
+            10 => Periph4Dma2::DsiRx,
+            11 => Periph4Dma2::DsiTx,
+            22 => Periph4Dma2::DbiTx,
             _ => unreachable!(),
         }
     }
     /// Set source peripheral for DMA 0/1.
     #[inline]
-    pub const fn set_src_periph4dma01(self, periph: Periph4DMA01) -> Self {
+    pub const fn set_src_periph4dma01(self, periph: Periph4Dma01) -> Self {
         Self((self.0 & !Self::SRC_PERIPH) | ((periph as u32) << 1))
     }
     /// Set source peripheral for DMA2.
     #[inline]
-    pub const fn set_src_periph4dma2(self, periph: Periph4DMA2) -> Self {
+    pub const fn set_src_periph4dma2(self, periph: Periph4Dma2) -> Self {
         Self((self.0 & !Self::SRC_PERIPH) | ((periph as u32) << 1))
     }
     /// Get source peripheral for DMA 0/1.
     #[inline]
-    pub const fn src_periph4dma01(self) -> Periph4DMA01 {
+    pub const fn src_periph4dma01(self) -> Periph4Dma01 {
         match ((self.0 & Self::SRC_PERIPH) >> 1) as u8 {
-            0 => Periph4DMA01::Uart0Rx,
-            1 => Periph4DMA01::Uart0Tx,
-            2 => Periph4DMA01::Uart1Rx,
-            3 => Periph4DMA01::Uart1Tx,
-            4 => Periph4DMA01::Uart2Rx,
-            5 => Periph4DMA01::Uart2Tx,
-            6 => Periph4DMA01::I2c0Rx,
-            7 => Periph4DMA01::I2c0Tx,
-            8 => Periph4DMA01::IrTx,
-            9 => Periph4DMA01::GpioTx,
-            10 => Periph4DMA01::Spi0Rx,
-            11 => Periph4DMA01::Spi0Tx,
-            12 => Periph4DMA01::AudioRx,
-            13 => Periph4DMA01::AudioTx,
-            14 => Periph4DMA01::I2c1Rx,
-            15 => Periph4DMA01::I2c1Tx,
-            16 => Periph4DMA01::I2sRx,
-            17 => Periph4DMA01::I2sTx,
-            18 => Periph4DMA01::PdmRx,
-            22 => Periph4DMA01::GpAdc,
-            23 => Periph4DMA01::GpDac,
+            0 => Periph4Dma01::Uart0Rx,
+            1 => Periph4Dma01::Uart0Tx,
+            2 => Periph4Dma01::Uart1Rx,
+            3 => Periph4Dma01::Uart1Tx,
+            4 => Periph4Dma01::Uart2Rx,
+            5 => Periph4Dma01::Uart2Tx,
+            6 => Periph4Dma01::I2c0Rx,
+            7 => Periph4Dma01::I2c0Tx,
+            8 => Periph4Dma01::IrTx,
+            9 => Periph4Dma01::GpioTx,
+            10 => Periph4Dma01::Spi0Rx,
+            11 => Periph4Dma01::Spi0Tx,
+            12 => Periph4Dma01::AudioRx,
+            13 => Periph4Dma01::AudioTx,
+            14 => Periph4Dma01::I2c1Rx,
+            15 => Periph4Dma01::I2c1Tx,
+            16 => Periph4Dma01::I2sRx,
+            17 => Periph4Dma01::I2sTx,
+            18 => Periph4Dma01::PdmRx,
+            22 => Periph4Dma01::GpAdc,
+            23 => Periph4Dma01::GpDac,
             _ => unreachable!(),
         }
     }
     /// Get source peripheral for DMA2.
     #[inline]
-    pub const fn src_periph4dma2(self) -> Periph4DMA2 {
+    pub const fn src_periph4dma2(self) -> Periph4Dma2 {
         match ((self.0 & Self::SRC_PERIPH) >> 1) as u8 {
-            0 => Periph4DMA2::Uart3Rx,
-            1 => Periph4DMA2::Uart3Tx,
-            2 => Periph4DMA2::Spi1Rx,
-            3 => Periph4DMA2::Spi1Tx,
-            6 => Periph4DMA2::I2c2Rx,
-            7 => Periph4DMA2::I2c2Tx,
-            8 => Periph4DMA2::I2c3Rx,
-            9 => Periph4DMA2::I2c3Tx,
-            10 => Periph4DMA2::DsiRx,
-            11 => Periph4DMA2::DsiTx,
-            22 => Periph4DMA2::DbiTx,
+            0 => Periph4Dma2::Uart3Rx,
+            1 => Periph4Dma2::Uart3Tx,
+            2 => Periph4Dma2::Spi1Rx,
+            3 => Periph4Dma2::Spi1Tx,
+            6 => Periph4Dma2::I2c2Rx,
+            7 => Periph4Dma2::I2c2Tx,
+            8 => Periph4Dma2::I2c3Rx,
+            9 => Periph4Dma2::I2c3Tx,
+            10 => Periph4Dma2::DsiRx,
+            11 => Periph4Dma2::DsiTx,
+            22 => Periph4Dma2::DbiTx,
             _ => unreachable!(),
         }
     }
@@ -754,12 +795,294 @@ impl ChannelConfig {
     }
 }
 
+/// DMA peripheral data register address definition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DmaAddr {
+    Uart0Tx = 0x2000A000 + 0x88,
+    Uart0Rx = 0x2000A000 + 0x8C,
+    Uart1Tx = 0x2000A100 + 0x88,
+    Uart1Rx = 0x2000A100 + 0x8C,
+    Uart2Tx = 0x2000AA00 + 0x88,
+    Uart2Rx = 0x2000AA00 + 0x8C,
+    Uart3Tx = 0x30002000 + 0x88,
+    Uart3Rx = 0x30002000 + 0x8C,
+    I2c0Tx = 0x2000A300 + 0x88,
+    I2c0Rx = 0x2000A300 + 0x8C,
+    I2c1Tx = 0x2000A900 + 0x88,
+    I2c1Rx = 0x2000A900 + 0x8C,
+    I2c2Tx = 0x30003000 + 0x88,
+    I2c2Rx = 0x30003000 + 0x8C,
+    I2c3Tx = 0x30004000 + 0x88,
+    I2c3Rx = 0x30004000 + 0x8C,
+    Spi0Tx = 0x2000A200 + 0x88,
+    Spi0Rx = 0x2000A200 + 0x8C,
+    Spi1Tx = 0x30008000 + 0x88,
+    Spi1Rx = 0x30008000 + 0x8C,
+    I2sTx = 0x2000AB00 + 0x88,
+    I2sRx = 0x2000AB00 + 0x8C,
+    AdcRx = 0x20002000 + 0x04,
+    DacTx = 0x20002000 + 0x48,
+    IrTx = 0x2000A600 + 0x88,
+    WoTx = 0x20000000 + 0xB04,
+}
+
+/// Managed Direct Memory Access peripheral.
+pub struct Dma<DMA: Deref<Target = RegisterBlock>> {
+    dma: DMA,
+    channel: u8,
+}
+
+/// Direct Memory Access channel configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DmaChannelConfig {
+    pub direction: DmaMode,
+    pub src_req: DmaPeriphReq,
+    pub dst_req: DmaPeriphReq,
+    pub src_addr_inc: bool,
+    pub dst_addr_inc: bool,
+    pub src_burst_size: BurstSize,
+    pub dst_burst_size: BurstSize,
+    pub src_transfer_width: TransferWidth,
+    pub dst_transfer_width: TransferWidth,
+}
+
+impl<DMA: Deref<Target = RegisterBlock>> Dma<DMA> {
+    /// Create a new DMA Peripheral Interface instance.
+    #[inline]
+    pub fn new(
+        dma: DMA,
+        dma_idx: u8,
+        channel: u8,
+        channel_config: DmaChannelConfig,
+        glb: &glb::v2::RegisterBlock,
+    ) -> Self {
+        unsafe {
+            glb.clock_config_0.modify(|val| val.enable_dma());
+            // TODO: more proper usage.
+            match dma_idx {
+                0 => glb.clock_config_1.modify(|val| val.enable_dma::<0>()),
+                1 => glb.clock_config_1.modify(|val| val.enable_dma::<1>()),
+                2 => glb.clock_config_1.modify(|val| val.enable_dma::<2>()),
+                _ => unreachable!(),
+            }
+            dma.global_config.modify(|val| val.enable_dma());
+            dma.channels[channel as usize]
+                .config
+                .modify(|val| val.disable_ch());
+            if channel_config.src_addr_inc {
+                dma.channels[channel as usize]
+                    .control
+                    .modify(|val| val.enable_src_addr_inc());
+            } else {
+                dma.channels[channel as usize]
+                    .control
+                    .modify(|val| val.disable_src_addr_inc());
+            }
+            if channel_config.dst_addr_inc {
+                dma.channels[channel as usize]
+                    .control
+                    .modify(|val| val.enable_dst_addr_inc());
+            } else {
+                dma.channels[channel as usize]
+                    .control
+                    .modify(|val| val.disable_dst_addr_inc());
+            }
+            dma.channels[channel as usize].control.modify(|val| {
+                val.set_src_transfer_width(channel_config.src_transfer_width)
+                    .set_dst_transfer_width(channel_config.dst_transfer_width)
+                    .set_src_bst_size(channel_config.src_burst_size)
+                    .set_dst_bst_size(channel_config.dst_burst_size)
+            });
+            dma.channels[channel as usize]
+                .config
+                .modify(|val| val.set_dma_mode(channel_config.direction));
+            match channel_config.src_req {
+                DmaPeriphReq::Dma01(periph) => {
+                    dma.channels[channel as usize]
+                        .config
+                        .modify(|val| val.set_src_periph4dma01(periph));
+                }
+                DmaPeriphReq::Dma2(periph) => {
+                    dma.channels[channel as usize]
+                        .config
+                        .modify(|val| val.set_src_periph4dma2(periph));
+                }
+                DmaPeriphReq::None => {}
+            }
+            match channel_config.dst_req {
+                DmaPeriphReq::Dma01(periph) => {
+                    dma.channels[channel as usize]
+                        .config
+                        .modify(|val| val.set_dst_periph4dma01(periph));
+                }
+                DmaPeriphReq::Dma2(periph) => {
+                    dma.channels[channel as usize]
+                        .config
+                        .modify(|val| val.set_dst_periph4dma2(periph));
+                }
+                DmaPeriphReq::None => {}
+            }
+            dma.channels[channel as usize]
+                .config
+                .modify(|val| val.enable_cplt_int().enable_err_int());
+            dma.channels[channel as usize]
+                .control
+                .modify(|val| val.disable_cplt_int());
+            dma.interrupts
+                .transfer_complete_clear
+                .write(TransferCompleteClear(0x0).clear_cplt_int(channel));
+            dma.interrupts
+                .error_clear
+                .write(ErrorClear(0x0).clear_err_int(channel));
+        }
+        Self { dma, channel }
+    }
+    /// Configure linked list items.
+    #[inline]
+    pub fn lli_config(
+        &self,
+        lli_pool: &mut [LliPool],
+        lli_count: u32,
+        mut src_addr: u32,
+        mut dst_addr: u32,
+        transfer_offset: u32,
+        last_transfer_len: u32,
+    ) {
+        let mut ctrl_cfg = self.dma.channels[self.channel as usize].control.read();
+        ctrl_cfg = ctrl_cfg.set_transfer_size(4064).disable_cplt_int();
+
+        for i in 0..lli_count {
+            lli_pool[i as usize].src_addr = src_addr;
+            lli_pool[i as usize].dst_addr = dst_addr;
+            lli_pool[i as usize].next_lli = 0;
+
+            if ctrl_cfg.is_src_addr_inc_enabled() {
+                src_addr = src_addr + transfer_offset;
+            }
+            if ctrl_cfg.is_dst_addr_inc_enabled() {
+                dst_addr = dst_addr + transfer_offset;
+            }
+            if i == lli_count - 1 {
+                ctrl_cfg = ctrl_cfg
+                    .set_transfer_size(last_transfer_len as u16)
+                    .enable_cplt_int();
+            }
+            if i != 0 {
+                lli_pool[(i - 1) as usize].next_lli =
+                    (&lli_pool[i as usize] as *const LliPool) as u32;
+            }
+
+            lli_pool[i as usize].control = ctrl_cfg;
+        }
+    }
+    /// Reload linked list items.
+    #[inline]
+    pub fn lli_reload(
+        &self,
+        lli_pool: &mut [LliPool],
+        max_lli_count: u32,
+        transfer: &mut [LliTransfer],
+        count: u32,
+    ) -> i32 {
+        let ctrl_cfg = self.dma.channels[self.channel as usize].control.read();
+
+        let mut lli_count_used_offset = 0;
+        let actual_transfer_offset = match ctrl_cfg.src_transfer_width() {
+            TransferWidth::Byte => 4064,
+            TransferWidth::HalfWord => 4064 << 1,
+            TransferWidth::Word => 4064 << 2,
+            TransferWidth::DoubleWord => 4064 << 3,
+        };
+
+        for i in 0..count {
+            let actual_transfer_len = match ctrl_cfg.src_transfer_width() {
+                TransferWidth::Byte => transfer[i as usize].nbytes,
+                TransferWidth::HalfWord => transfer[i as usize].nbytes >> 1,
+                TransferWidth::Word => transfer[i as usize].nbytes >> 2,
+                TransferWidth::DoubleWord => transfer[i as usize].nbytes >> 3,
+            };
+
+            let mut current_lli_count = actual_transfer_len / 4064 + 1;
+            let mut last_transfer_len = actual_transfer_len % 4064;
+
+            if current_lli_count > 1 && last_transfer_len < (4095 - 4064) {
+                current_lli_count = current_lli_count - 1;
+                last_transfer_len = last_transfer_len + 4064;
+            }
+
+            self.lli_config(
+                &mut lli_pool[lli_count_used_offset..],
+                current_lli_count,
+                transfer[i as usize].src_addr,
+                transfer[i as usize].dst_addr,
+                actual_transfer_offset,
+                last_transfer_len,
+            );
+
+            if i != 0 {
+                lli_pool[lli_count_used_offset - 1].next_lli =
+                    (&lli_pool[lli_count_used_offset] as *const LliPool) as u32;
+            }
+
+            lli_count_used_offset = lli_count_used_offset + current_lli_count as usize;
+
+            if lli_count_used_offset > max_lli_count as usize {
+                // Out of memory.
+                return -12;
+            }
+        }
+
+        unsafe {
+            self.dma.channels[self.channel as usize]
+                .source_address
+                .write(lli_pool[0].src_addr);
+            self.dma.channels[self.channel as usize]
+                .destination_address
+                .write(lli_pool[0].dst_addr);
+            self.dma.channels[self.channel as usize]
+                .linked_list_item
+                .write(lli_pool[0].next_lli);
+            self.dma.channels[self.channel as usize]
+                .control
+                .write(lli_pool[0].control);
+        }
+        lli_count_used_offset as i32
+    }
+    /// Start DMA transfer.
+    #[inline]
+    pub fn start(&self) {
+        unsafe {
+            self.dma.channels[self.channel as usize]
+                .config
+                .modify(|val| val.enable_ch());
+        }
+    }
+    /// Stop DMA transfer.
+    #[inline]
+    pub fn stop(&self) {
+        unsafe {
+            self.dma.channels[self.channel as usize]
+                .config
+                .modify(|val| val.disable_ch());
+        }
+    }
+    /// Check if DMA transfer is complete.
+    #[inline]
+    pub fn transfer_cplt(&self) -> bool {
+        self.dma
+            .interrupts
+            .transfer_complete_state
+            .read()
+            .if_cplt_int_occurs(self.channel)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        BurstSize, ChannelConfig, ChannelRegisters, DMAMode, EnabledChannels, EndianMode,
+        BurstSize, ChannelConfig, ChannelRegisters, DmaMode, EnabledChannels, EndianMode,
         ErrorClear, ErrorState, GlobalConfig, GlobalState, InterruptRegisters, LliControl,
-        Periph4DMA01, Periph4DMA2, RawError, RawTransferComplete, RegisterBlock,
+        Periph4Dma01, Periph4Dma2, RawError, RawTransferComplete, RegisterBlock,
         TransferCompleteClear, TransferCompleteState, TransferWidth,
     };
     use memoffset::offset_of;
@@ -838,11 +1161,11 @@ mod tests {
         assert_eq!(val.ahb_master_endian_mode(), EndianMode::LittleEndian);
         assert_eq!(val.0, 0x00000000);
 
-        val = val.enable_smdma();
-        assert!(val.is_smdma_enabled());
+        val = val.enable_dma();
+        assert!(val.is_dma_enabled());
         assert_eq!(val.0, 0x00000001);
-        val = val.disable_smdma();
-        assert!(!val.is_smdma_enabled());
+        val = val.disable_dma();
+        assert!(!val.is_dma_enabled());
         assert_eq!(val.0, 0x00000000);
     }
 
@@ -988,14 +1311,14 @@ mod tests {
         // The number 'i' is not related to the actual register, but only to make the code more concise.
         for i in 0..8 as u8 {
             let tmp_mode = match i {
-                0 => DMAMode::Mem2Mem,
-                1 => DMAMode::Mem2Periph,
-                2 => DMAMode::Periph2Mem,
-                3 => DMAMode::Periph2Periph,
-                4 => DMAMode::Periph2PeriphCtrlByDst,
-                5 => DMAMode::Mem2PeriphCtrlByPeriph,
-                6 => DMAMode::Periph2MemCtrlByPeriph,
-                _ => DMAMode::Periph2PeriphCtrlBySrc,
+                0 => DmaMode::Mem2Mem,
+                1 => DmaMode::Mem2Periph,
+                2 => DmaMode::Periph2Mem,
+                3 => DmaMode::Periph2Periph,
+                4 => DmaMode::Periph2PeriphCtrlByDst,
+                5 => DmaMode::Mem2PeriphCtrlByPeriph,
+                6 => DmaMode::Periph2MemCtrlByPeriph,
+                _ => DmaMode::Periph2PeriphCtrlBySrc,
             };
             let tmp_val = match i {
                 0 => 0x00000000,
@@ -1017,27 +1340,27 @@ mod tests {
         // The number 'i' is not related to the actual register, but only to make the code more concise.
         for i in 0..21 as u8 {
             let tmp_periph = match i {
-                0 => Periph4DMA01::Uart0Rx,
-                1 => Periph4DMA01::Uart0Tx,
-                2 => Periph4DMA01::Uart1Rx,
-                3 => Periph4DMA01::Uart1Tx,
-                4 => Periph4DMA01::Uart2Rx,
-                5 => Periph4DMA01::Uart2Tx,
-                6 => Periph4DMA01::I2c0Rx,
-                7 => Periph4DMA01::I2c0Tx,
-                8 => Periph4DMA01::IrTx,
-                9 => Periph4DMA01::GpioTx,
-                10 => Periph4DMA01::Spi0Rx,
-                11 => Periph4DMA01::Spi0Tx,
-                12 => Periph4DMA01::AudioRx,
-                13 => Periph4DMA01::AudioTx,
-                14 => Periph4DMA01::I2c1Rx,
-                15 => Periph4DMA01::I2c1Tx,
-                16 => Periph4DMA01::I2sRx,
-                17 => Periph4DMA01::I2sTx,
-                18 => Periph4DMA01::PdmRx,
-                19 => Periph4DMA01::GpAdc,
-                _ => Periph4DMA01::GpDac,
+                0 => Periph4Dma01::Uart0Rx,
+                1 => Periph4Dma01::Uart0Tx,
+                2 => Periph4Dma01::Uart1Rx,
+                3 => Periph4Dma01::Uart1Tx,
+                4 => Periph4Dma01::Uart2Rx,
+                5 => Periph4Dma01::Uart2Tx,
+                6 => Periph4Dma01::I2c0Rx,
+                7 => Periph4Dma01::I2c0Tx,
+                8 => Periph4Dma01::IrTx,
+                9 => Periph4Dma01::GpioTx,
+                10 => Periph4Dma01::Spi0Rx,
+                11 => Periph4Dma01::Spi0Tx,
+                12 => Periph4Dma01::AudioRx,
+                13 => Periph4Dma01::AudioTx,
+                14 => Periph4Dma01::I2c1Rx,
+                15 => Periph4Dma01::I2c1Tx,
+                16 => Periph4Dma01::I2sRx,
+                17 => Periph4Dma01::I2sTx,
+                18 => Periph4Dma01::PdmRx,
+                19 => Periph4Dma01::GpAdc,
+                _ => Periph4Dma01::GpDac,
             };
             let tmp_val = match i {
                 0 => 0x00000000,
@@ -1071,17 +1394,17 @@ mod tests {
         // The number 'i' is not related to the actual register, but only to make the code more concise.
         for i in 0..11 as u8 {
             let tmp_periph = match i {
-                0 => Periph4DMA2::Uart3Rx,
-                1 => Periph4DMA2::Uart3Tx,
-                2 => Periph4DMA2::Spi1Rx,
-                3 => Periph4DMA2::Spi1Tx,
-                4 => Periph4DMA2::I2c2Rx,
-                5 => Periph4DMA2::I2c2Tx,
-                6 => Periph4DMA2::I2c3Rx,
-                7 => Periph4DMA2::I2c3Tx,
-                8 => Periph4DMA2::DsiRx,
-                9 => Periph4DMA2::DsiTx,
-                _ => Periph4DMA2::DbiTx,
+                0 => Periph4Dma2::Uart3Rx,
+                1 => Periph4Dma2::Uart3Tx,
+                2 => Periph4Dma2::Spi1Rx,
+                3 => Periph4Dma2::Spi1Tx,
+                4 => Periph4Dma2::I2c2Rx,
+                5 => Periph4Dma2::I2c2Tx,
+                6 => Periph4Dma2::I2c3Rx,
+                7 => Periph4Dma2::I2c3Tx,
+                8 => Periph4Dma2::DsiRx,
+                9 => Periph4Dma2::DsiTx,
+                _ => Periph4Dma2::DbiTx,
             };
             let tmp_val = match i {
                 0 => 0x00000000,
@@ -1105,27 +1428,27 @@ mod tests {
         // The number 'i' is not related to the actual register, but only to make the code more concise.
         for i in 0..21 as u8 {
             let tmp_periph = match i {
-                0 => Periph4DMA01::Uart0Rx,
-                1 => Periph4DMA01::Uart0Tx,
-                2 => Periph4DMA01::Uart1Rx,
-                3 => Periph4DMA01::Uart1Tx,
-                4 => Periph4DMA01::Uart2Rx,
-                5 => Periph4DMA01::Uart2Tx,
-                6 => Periph4DMA01::I2c0Rx,
-                7 => Periph4DMA01::I2c0Tx,
-                8 => Periph4DMA01::IrTx,
-                9 => Periph4DMA01::GpioTx,
-                10 => Periph4DMA01::Spi0Rx,
-                11 => Periph4DMA01::Spi0Tx,
-                12 => Periph4DMA01::AudioRx,
-                13 => Periph4DMA01::AudioTx,
-                14 => Periph4DMA01::I2c1Rx,
-                15 => Periph4DMA01::I2c1Tx,
-                16 => Periph4DMA01::I2sRx,
-                17 => Periph4DMA01::I2sTx,
-                18 => Periph4DMA01::PdmRx,
-                19 => Periph4DMA01::GpAdc,
-                _ => Periph4DMA01::GpDac,
+                0 => Periph4Dma01::Uart0Rx,
+                1 => Periph4Dma01::Uart0Tx,
+                2 => Periph4Dma01::Uart1Rx,
+                3 => Periph4Dma01::Uart1Tx,
+                4 => Periph4Dma01::Uart2Rx,
+                5 => Periph4Dma01::Uart2Tx,
+                6 => Periph4Dma01::I2c0Rx,
+                7 => Periph4Dma01::I2c0Tx,
+                8 => Periph4Dma01::IrTx,
+                9 => Periph4Dma01::GpioTx,
+                10 => Periph4Dma01::Spi0Rx,
+                11 => Periph4Dma01::Spi0Tx,
+                12 => Periph4Dma01::AudioRx,
+                13 => Periph4Dma01::AudioTx,
+                14 => Periph4Dma01::I2c1Rx,
+                15 => Periph4Dma01::I2c1Tx,
+                16 => Periph4Dma01::I2sRx,
+                17 => Periph4Dma01::I2sTx,
+                18 => Periph4Dma01::PdmRx,
+                19 => Periph4Dma01::GpAdc,
+                _ => Periph4Dma01::GpDac,
             };
             let tmp_val = match i {
                 0 => 0x00000000,
@@ -1159,17 +1482,17 @@ mod tests {
         // The number 'i' is not related to the actual register, but only to make the code more concise.
         for i in 0..11 as u8 {
             let tmp_periph = match i {
-                0 => Periph4DMA2::Uart3Rx,
-                1 => Periph4DMA2::Uart3Tx,
-                2 => Periph4DMA2::Spi1Rx,
-                3 => Periph4DMA2::Spi1Tx,
-                4 => Periph4DMA2::I2c2Rx,
-                5 => Periph4DMA2::I2c2Tx,
-                6 => Periph4DMA2::I2c3Rx,
-                7 => Periph4DMA2::I2c3Tx,
-                8 => Periph4DMA2::DsiRx,
-                9 => Periph4DMA2::DsiTx,
-                _ => Periph4DMA2::DbiTx,
+                0 => Periph4Dma2::Uart3Rx,
+                1 => Periph4Dma2::Uart3Tx,
+                2 => Periph4Dma2::Spi1Rx,
+                3 => Periph4Dma2::Spi1Tx,
+                4 => Periph4Dma2::I2c2Rx,
+                5 => Periph4Dma2::I2c2Tx,
+                6 => Periph4Dma2::I2c3Rx,
+                7 => Periph4Dma2::I2c3Tx,
+                8 => Periph4Dma2::DsiRx,
+                9 => Periph4Dma2::DsiTx,
+                _ => Periph4Dma2::DbiTx,
             };
             let tmp_val = match i {
                 0 => 0x00000000,

--- a/bouffalo-hal/src/glb/v2.rs
+++ b/bouffalo-hal/src/glb/v2.rs
@@ -29,9 +29,9 @@ pub struct RegisterBlock {
     pub clock_config_0: RW<ClockConfig0>,
     /// Clock generation configuration 1.
     pub clock_config_1: RW<ClockConfig1>,
-    /// Clock generation configuration 1.
+    /// Clock generation configuration 2.
     pub clock_config_2: RW<ClockConfig2>,
-    /// Clock generation configuration 1.
+    /// Clock generation configuration 3.
     pub clock_config_3: RW<ClockConfig3>,
     _reserved7: [u8; 0x140],
     /// LDO12UHS config.
@@ -443,7 +443,7 @@ pub enum SpiMode {
     Slave = 1,
 }
 
-/// Clock generation configuration register 1.
+/// Clock generation configuration register 0.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[repr(transparent)]
 pub struct ClockConfig0(u32);

--- a/bouffalo-hal/src/glb/v2.rs
+++ b/bouffalo-hal/src/glb/v2.rs
@@ -24,11 +24,16 @@ pub struct RegisterBlock {
     pub sdh_config: RW<SdhConfig>,
     _reserved5: [u8; 0xdd],
     pub param_config: RW<ParamConfig>,
-    _reserved6: [u8; 0x70],
-    // TODO: clock_config_0, clock_config_2, clock_config_3 registers
+    _reserved6: [u8; 0x6c],
+    /// Clock generation configuration 0.
+    pub clock_config_0: RW<ClockConfig0>,
     /// Clock generation configuration 1.
     pub clock_config_1: RW<ClockConfig1>,
-    _reserved7: [u8; 0x148],
+    /// Clock generation configuration 1.
+    pub clock_config_2: RW<ClockConfig2>,
+    /// Clock generation configuration 1.
+    pub clock_config_3: RW<ClockConfig3>,
+    _reserved7: [u8; 0x140],
     /// LDO12UHS config.
     pub ldo12uhs_config: RW<Ldo12uhsConfig>,
     _reserved8: [u8; 0x1f0],
@@ -441,16 +446,78 @@ pub enum SpiMode {
 /// Clock generation configuration register 1.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[repr(transparent)]
+pub struct ClockConfig0(u32);
+
+impl ClockConfig0 {
+    // const CCI: u32 = 0x1 << 4;
+    const DMA: u32 = 0x1 << 3;
+    // const SEC: u32 = 0x1 << 2;
+    // const SDU: u32 = 0x1 << 1;
+    // const CPU: u32 = 0x1;
+
+    /// Enable clock gate for Direct Memory Access controller.
+    #[inline]
+    pub const fn enable_dma(self) -> Self {
+        Self(self.0 | Self::DMA)
+    }
+    /// Disable clock gate for Direct Memory Access controller.
+    #[inline]
+    pub const fn disable_dma(self) -> Self {
+        Self(self.0 & !Self::DMA)
+    }
+    /// Check if clock gate for Direct Memory Access controller is enabled.
+    #[inline]
+    pub const fn is_dma_enabled(self) -> bool {
+        (self.0 & Self::DMA) != 0
+    }
+    // TODO: implment left fields.
+}
+
+/// Clock generation configuration register 1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
 pub struct ClockConfig1(u32);
 
 impl ClockConfig1 {
+    const DMA0: u32 = 0x1 << 12;
     const UART0: u32 = 0x1 << 16;
     const UART1: u32 = 0x1 << 17;
     const I2C: u32 = 0x1 << 19;
     const PWM: u32 = 0x1 << 20;
+    const DMA2: u32 = 0x1 << 24;
     const UART2: u32 = 0x1 << 26;
     const LZ4D: u32 = 0x1 << 29;
 
+    /// Enable clock gate for Direct Memory Access controller 0.
+    #[inline]
+    pub const fn enable_dma<const I: usize>(self) -> Self {
+        match I {
+            0 => Self(self.0 | Self::DMA0),
+            1 => self,
+            2 => Self(self.0 | Self::DMA2),
+            _ => unreachable!(),
+        }
+    }
+    /// Disable clock gate for Direct Memory Access controller 0.
+    #[inline]
+    pub const fn disable_dma<const I: usize>(self) -> Self {
+        match I {
+            0 => Self(self.0 & !Self::DMA0),
+            1 => self,
+            2 => Self(self.0 & !Self::DMA2),
+            _ => unreachable!(),
+        }
+    }
+    /// Check if clock gate for Direct Memory Access controller 0 is enabled.
+    #[inline]
+    pub const fn is_dma_enabled<const I: usize>(self) -> bool {
+        match I {
+            0 => (self.0 & Self::DMA0) != 0,
+            1 => true,
+            2 => (self.0 & Self::DMA2) != 0,
+            _ => unreachable!(),
+        }
+    }
     /// Enable clock gate for Universal Asynchronous Receiver/Transmitter peripheral.
     #[inline]
     pub const fn enable_uart<const I: usize>(self) -> Self {
@@ -529,6 +596,24 @@ impl ClockConfig1 {
     pub const fn is_lz4d_enabled(self) -> bool {
         self.0 & Self::LZ4D != 0
     }
+}
+
+/// Clock generation configuration register 2.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct ClockConfig2(u32);
+
+impl ClockConfig2 {
+    // TODO
+}
+
+/// Clock generation configuration register 3.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct ClockConfig3(u32);
+
+impl ClockConfig3 {
+    // TODO
 }
 
 /// Generic Purpose Input/Output Configuration register.
@@ -862,7 +947,10 @@ mod tests {
         assert_eq!(offset_of!(RegisterBlock, pwm_config), 0x1d0);
         assert_eq!(offset_of!(RegisterBlock, sdh_config), 0x430);
         assert_eq!(offset_of!(RegisterBlock, param_config), 0x510);
+        assert_eq!(offset_of!(RegisterBlock, clock_config_0), 0x580);
         assert_eq!(offset_of!(RegisterBlock, clock_config_1), 0x584);
+        assert_eq!(offset_of!(RegisterBlock, clock_config_2), 0x588);
+        assert_eq!(offset_of!(RegisterBlock, clock_config_3), 0x58c);
         assert_eq!(offset_of!(RegisterBlock, ldo12uhs_config), 0x6d0);
         assert_eq!(offset_of!(RegisterBlock, gpio_config), 0x8c4);
         assert_eq!(offset_of!(RegisterBlock, gpio_input), 0xac4);

--- a/bouffalo-hal/src/uart/blocking.rs
+++ b/bouffalo-hal/src/uart/blocking.rs
@@ -39,6 +39,34 @@ impl<UART: Deref<Target = RegisterBlock>, PADS> BlockingSerial<UART, PADS> {
         Ok(Self { uart, pads })
     }
 
+    /// Enable transmit DMA.
+    #[inline]
+    pub fn enable_tx_dma(self) -> Self {
+        unsafe {
+            self.uart
+                .fifo_config_1
+                .modify(|val| val.set_transmit_threshold(7));
+            self.uart
+                .fifo_config_0
+                .modify(|val| val.enable_transmit_dma().clear_transmit_fifo());
+        }
+        self
+    }
+
+    /// Enable receive DMA.
+    #[inline]
+    pub fn enable_rx_dma(self) -> Self {
+        unsafe {
+            self.uart
+                .fifo_config_1
+                .modify(|val| val.set_receive_threshold(7));
+            self.uart
+                .fifo_config_0
+                .modify(|val| val.enable_receive_dma().clear_receive_fifo());
+        }
+        self
+    }
+
     /// Release serial instance and return its peripheral and pads.
     #[inline]
     pub fn free(self) -> (UART, PADS) {

--- a/bouffalo-rt/src/soc/bl808.rs
+++ b/bouffalo-rt/src/soc/bl808.rs
@@ -531,11 +531,47 @@ impl plic::InterruptSource for RawPlicSource {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum DspInterrupt {
     /// UART3 interrupt.
-    UART3 = 16 + 4,
-    // TODO other interrupts.
-    // /// I2C2 interrupt.
-    // I2C2 = 16 + 5,
-    // ...
+    Uart3 = 16 + 4,
+    /// I2C2 interrupt.
+    I2c2 = 16 + 5,
+    /// I2C3 interrupt.
+    I2c3 = 16 + 6,
+    /// SPI1 interrupt.
+    Spi1 = 16 + 7,
+    /// DMA2 interrupt 0.
+    Dma2Int0 = 16 + 24,
+    /// DMA2 interrupt 1.
+    Dma2Int1 = 16 + 25,
+    /// DMA2 interrupt 2.
+    Dma2Int2 = 16 + 26,
+    /// DMA2 interrupt 3.
+    Dma2Int3 = 16 + 27,
+    /// DMA2 interrupt 4.
+    Dma2Int4 = 16 + 28,
+    /// DMA2 interrupt 5.
+    Dma2Int5 = 16 + 29,
+    /// DMA2 interrupt 6.
+    Dma2Int6 = 16 + 30,
+    /// DMA2 interrupt 7.
+    Dma2Int7 = 16 + 31,
+    /// EMAC2 interrupt.
+    Emac2 = 16 + 36,
+    /// DMA2D interrupt 0.
+    Dma2dInt0 = 16 + 45,
+    /// DMA2D interrupt 1.
+    Dma2dInt1 = 16 + 46,
+    /// PWM interrupt.
+    Pwm = 16 + 48,
+    /// TIM1 channel 0 interrupt.
+    Tim1Ch0 = 16 + 61,
+    /// TIM1 interrupt.
+    Tim1Ch1 = 16 + 62,
+    /// TIM1 WDT interrupt.
+    Tim1Wdt = 16 + 63,
+    /// AUDIO interrupt.
+    Audio = 16 + 64,
+    /// PDS interrupt.
+    Pds = 16 + 66,
 }
 
 impl plic::InterruptSource for DspInterrupt {
@@ -545,8 +581,55 @@ impl plic::InterruptSource for DspInterrupt {
     }
 }
 
-// TODO: MCU and Low-Power core interrupt source.
-// pub enum McuLpInterrupt { ... }
+/// MCU and Low-Power core interrupt source.
+pub enum McuLpInterrupt {
+    /// DMA0 all interrupt.
+    Dma0All = 16 + 15,
+    /// DMA1 all interrupt.
+    Dma1All = 16 + 16,
+    /// IR transmit interrupt.
+    IrTx = 16 + 19,
+    /// IR receive interrupt.
+    IrRx = 16 + 20,
+    /// USB interrupt.
+    Usb = 16 + 21,
+    /// EMAC interrupt.
+    Emac = 16 + 24,
+    /// GPADC DMA interrupt.
+    GpadcDma = 16 + 25,
+    /// SPI0 interrupt.
+    Spi0 = 16 + 27,
+    /// UART0 interrupt.
+    Uart0 = 16 + 28,
+    /// UART1 interrupt.
+    Uart1 = 16 + 29,
+    /// UART2 interrupt.
+    Uart2 = 16 + 30,
+    /// GPIO DMA interrupt.
+    GpioDma = 16 + 31,
+    /// I2C0 interrupt.
+    I2c0 = 16 + 32,
+    /// I2C1 interrupt.
+    I2c1 = 16 + 39,
+    /// PWM interrupt.
+    Pwm = 16 + 33,
+    /// TIM0 channel 0 interrupt.
+    Tim0Ch0 = 16 + 36,
+    /// TIM0 channel 1 interrupt.
+    Tim0Ch1 = 16 + 37,
+    /// TIM0 WDT interrupt.
+    Tim0Wdt = 16 + 38,
+    /// I2S interrupt.
+    I2s = 16 + 40,
+    /// GPIO interrupt.
+    Gpio = 16 + 44,
+    /// PDS wakeup interrupt.
+    PdsWakeup = 16 + 50,
+    /// HBN out 0 interrupt.
+    HbnOut0 = 16 + 51,
+    /// HBN out 1 interrupt.
+    HbnOut1 = 16 + 52,
+}
 
 /// Clock configuration at boot-time.
 #[cfg(any(doc, feature = "bl808-mcu", feature = "bl808-dsp"))]
@@ -860,6 +943,12 @@ pub struct Peripherals<'a> {
     pub psram: PSRAM,
     /// Secure Digital High Capacity peripheral.
     pub sdh: SDH,
+    /// Direct Memory Access peripheral 0.
+    pub dma0: DMA0,
+    /// Direct Memory Access peripheral 1.
+    pub dma1: DMA1,
+    /// Direct Memory Access peripheral 2.
+    pub dma2: DMA2,
 }
 
 soc! {
@@ -881,12 +970,18 @@ soc! {
     pub struct UART2 => 0x2000AA00, bouffalo_hal::uart::RegisterBlock;
     /// Hardware LZ4 Decompressor.
     pub struct LZ4D => 0x2000AD00, bouffalo_hal::lz4d::RegisterBlock;
+    /// Direct Memory Access peripheral 0.
+    pub struct DMA0 => 0x2000C000, bouffalo_hal::dma::RegisterBlock;
     /// Hibernation control peripheral.
     pub struct HBN => 0x2000F000, bouffalo_hal::hbn::RegisterBlock;
     /// Secure Digital High Capacity peripheral.
     pub struct SDH => 0x20060000, bouffalo_hal::sdio::RegisterBlock;
     /// Ethernet Media Access Control peripheral.
     pub struct EMAC => 0x20070000, bouffalo_hal::emac::RegisterBlock;
+    /// Direct Memory Access peripheral 1.
+    pub struct DMA1 => 0x20071000, bouffalo_hal::dma::RegisterBlock;
+    /// Direct Memory Access peripheral 2.
+    pub struct DMA2 => 0x30001000, bouffalo_hal::dma::RegisterBlock;
     /// Universal Asynchronous Receiver/Transmitter 3 with fixed base address.
     pub struct UART3 => 0x30002000, bouffalo_hal::uart::RegisterBlock;
     /// Inter-Integrated Circuit bus 2 with fixed base address.
@@ -938,6 +1033,9 @@ pub fn __rom_init_params(xtal_hz: u32) -> (Peripherals<'static>, Clocks) {
         mmglb: MMGLB { _private: () },
         psram: PSRAM { _private: () },
         sdh: SDH { _private: () },
+        dma0: DMA0 { _private: () },
+        dma1: DMA1 { _private: () },
+        dma2: DMA2 { _private: () },
     };
     let clocks = Clocks {
         xtal: Hertz(xtal_hz),

--- a/examples/peripherals/uart-async-demo/src/main.rs
+++ b/examples/peripherals/uart-async-demo/src/main.rs
@@ -27,8 +27,8 @@ async fn async_main(p: Peripherals<'_>, c: Clocks) {
         .uart3
         .with_interrupt(config, (tx, rx), &c, &UART3_STATE)
         .unwrap();
-    p.plic.set_priority(DspInterrupt::UART3, 1);
-    p.plic.enable(DspInterrupt::UART3, D0Machine);
+    p.plic.set_priority(DspInterrupt::Uart3, 1);
+    p.plic.enable(DspInterrupt::Uart3, D0Machine);
 
     serial.write_all(b"Hello async/await world!\n").await.ok();
 

--- a/examples/peripherals/uart-dma-demo/Cargo.toml
+++ b/examples/peripherals/uart-dma-demo/Cargo.toml
@@ -11,7 +11,6 @@ bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-mcu"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
-embedded-io = "0.6.1"
 riscv = "0.12.1"
 
 [[bin]]

--- a/examples/peripherals/uart-dma-demo/Cargo.toml
+++ b/examples/peripherals/uart-dma-demo/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uart-dma-demo"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
+bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-mcu"] }
+panic-halt = "1.0.0"
+embedded-time = "0.12.1"
+embedded-io = "0.6.1"
+riscv = "0.12.1"
+
+[[bin]]
+name = "uart-dma-demo"
+test = false

--- a/examples/peripherals/uart-dma-demo/README.md
+++ b/examples/peripherals/uart-dma-demo/README.md
@@ -1,0 +1,15 @@
+UART peripheral demo with DMA
+
+Build this example with:
+
+```
+rustup target install riscv32imac-unknown-none-elf
+cargo build --target riscv32imac-unknown-none-elf --release -p uart-dma-demo
+```
+
+Compile the binary with:
+```
+rust-objcopy --binary-architecture=riscv32 --strip-all -O binary ./target/riscv32imac-unknown-none-elf/release/uart-dma-demo ./target/riscv32imac-unknown-none-elf/release/uart-dma-demo.bin
+```
+
+Open BL Dev Cube GUI, choose `M0` group, address `0x58000000`, then flash the binary to the board

--- a/examples/peripherals/uart-dma-demo/build.rs
+++ b/examples/peripherals/uart-dma-demo/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tbouffalo-rt.ld");
+}

--- a/examples/peripherals/uart-dma-demo/src/main.rs
+++ b/examples/peripherals/uart-dma-demo/src/main.rs
@@ -1,0 +1,67 @@
+#![no_std]
+#![no_main]
+
+use bouffalo_hal::{dma::*, prelude::*, uart::Config};
+use bouffalo_rt::{Clocks, Peripherals, entry};
+use embedded_time::rate::*;
+use panic_halt as _;
+
+#[entry]
+fn main(p: Peripherals, c: Clocks) -> ! {
+    let tx = p.gpio.io14.into_uart();
+    let rx = p.gpio.io15.into_uart();
+    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
+    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
+    let pads = ((tx, sig2), (rx, sig3));
+    let mut led = p.gpio.io8.into_floating_output();
+
+    let config = Config::default().set_baudrate(2000000.Bd());
+    let mut serial = p.uart0.freerun(config, pads, &c).unwrap().enable_tx_dma();
+    let tx_config = DmaChannelConfig {
+        direction: DmaMode::Mem2Periph,
+        src_req: DmaPeriphReq::None,
+        dst_req: DmaPeriphReq::Dma01(Periph4Dma01::Uart0Tx),
+        src_addr_inc: true,
+        dst_addr_inc: false,
+        src_burst_size: BurstSize::INCR1,
+        dst_burst_size: BurstSize::INCR1,
+        src_transfer_width: TransferWidth::Byte,
+        dst_transfer_width: TransferWidth::Byte,
+    };
+    let dma0_ch0 = Dma::new(p.dma0, 0, 0, tx_config, &p.glb);
+    let tx_lli_pool = &mut [LliPool::new(); 1];
+    let hello = b"Welcome to Universal Asynchronous Receiver/Transmitter with Direct Memory Access demo!\r\nHello world!";
+    let hello_ptr = hello.as_ptr();
+    let hello_len = hello.len();
+    let tx_transfer = &mut [LliTransfer {
+        src_addr: hello_ptr as u32,
+        dst_addr: DmaAddr::Uart0Tx as u32,
+        nbytes: hello_len as u32,
+    }];
+    if dma0_ch0.lli_reload(tx_lli_pool, 1, tx_transfer, 1) == -12 {
+        writeln!(serial, "Out of memory.").unwrap();
+        loop {
+            riscv::asm::delay(20_000);
+            led.set_high().ok();
+            riscv::asm::delay(20_000);
+            led.set_low().ok();
+        }
+    }
+    dma0_ch0.start();
+    let mut cnt = 0;
+    loop {
+        if dma0_ch0.transfer_cplt() {
+            cnt = cnt + 1;
+        }
+        if cnt == hello_len {
+            break;
+        }
+    }
+
+    loop {
+        led.set_low().ok();
+        riscv::asm::delay(100_000);
+        led.set_high().ok();
+        riscv::asm::delay(100_000);
+    }
+}

--- a/examples/peripherals/uart-dma-demo/src/main.rs
+++ b/examples/peripherals/uart-dma-demo/src/main.rs
@@ -28,7 +28,7 @@ fn main(p: Peripherals, c: Clocks) -> ! {
         src_transfer_width: TransferWidth::Byte,
         dst_transfer_width: TransferWidth::Byte,
     };
-    let dma0_ch0 = Dma::new(p.dma0, 0, 0, tx_config, &p.glb);
+    let dma0_ch0 = Dma::new::<0>(p.dma0, 0, tx_config, &p.glb);
     let tx_lli_pool = &mut [LliPool::new(); 1];
     let hello = b"Welcome to Universal Asynchronous Receiver/Transmitter with Direct Memory Access demo!\r\nHello world!";
     let hello_ptr = hello.as_ptr();
@@ -48,15 +48,9 @@ fn main(p: Peripherals, c: Clocks) -> ! {
         }
     }
     dma0_ch0.start();
-    let mut cnt = 0;
-    loop {
-        if dma0_ch0.transfer_cplt() {
-            cnt = cnt + 1;
-        }
-        if cnt == hello_len {
-            break;
-        }
-    }
+    // TODO: use interrupt or check transfer status to know when DMA transfer is done.
+    // Wait for transfer to complete.
+    riscv::asm::delay(500_000);
 
     loop {
         led.set_low().ok();


### PR DESCRIPTION
This PR adds DMA support for UART, tested the TX functionality of DMA0 and UART0, which worked fine. Other usage has not been tested yet, but it can be achieved by modifying `DmaChannelConfig`, `LliPool`, and `LliPool`.