### PR TITLE
test: update riscv dependency and add some unit tests

### DIFF
--- a/bouffalo-hal/src/glb/v2.rs
+++ b/bouffalo-hal/src/glb/v2.rs
@@ -845,11 +845,12 @@ impl Ldo12uhsConfig {
 #[cfg(test)]
 mod tests {
     use crate::glb::v2::SpiClockSource;
+    use crate::glb::v2::SpiMode;
 
     use super::{
-        Drive, Function, GpioConfig, I2cClockSource, I2cConfig, InterruptMode, Mode, Pull,
-        PwmConfig, PwmSignal0, PwmSignal1, RegisterBlock, SdhConfig, SpiConfig, UartConfig,
-        UartMuxGroup, UartSignal,
+        ClockConfig1, Drive, Function, GpioConfig, I2cClockSource, I2cConfig, InterruptMode, Mode,
+        ParamConfig, Pull, PwmConfig, PwmSignal0, PwmSignal1, RegisterBlock, SdhConfig, SpiConfig,
+        UartConfig, UartMuxGroup, UartSignal,
     };
     use memoffset::offset_of;
 
@@ -1123,6 +1124,27 @@ mod tests {
     }
 
     #[test]
+    fn struct_param_config_functions() {
+        let mut config = ParamConfig(0x0);
+
+        config = config.set_spi_mode::<0>(SpiMode::Master);
+        assert_eq!(config.0, 0x1000);
+        assert_eq!(config.spi_mode::<0>(), SpiMode::Master);
+
+        config = config.set_spi_mode::<0>(SpiMode::Slave);
+        assert_eq!(config.0, 0x0000);
+        assert_eq!(config.spi_mode::<0>(), SpiMode::Slave);
+
+        config = config.set_spi_mode::<1>(SpiMode::Master);
+        assert_eq!(config.0, 0x8000000);
+        assert_eq!(config.spi_mode::<1>(), SpiMode::Master);
+
+        config = config.set_spi_mode::<1>(SpiMode::Slave);
+        assert_eq!(config.0, 0x0000000);
+        assert_eq!(config.spi_mode::<1>(), SpiMode::Slave);
+    }
+
+    #[test]
     fn struct_sdh_config_functions() {
         let mut val = SdhConfig(0x0);
         val = val.enable_sdh_clk();
@@ -1141,4 +1163,74 @@ mod tests {
         assert_eq!(val.sdh_clk_div_len(), 0x7);
         assert_eq!(val.0, 0x0E00);
     }
+
+    #[test]
+    fn struct_clock_config1_functions() {
+        let mut config = ClockConfig1(0x0);
+
+        config = config.enable_uart::<0>();
+        assert_eq!(config.0, 0x10000);
+        assert!(config.is_uart_enabled::<0>());
+
+        config = config.disable_uart::<0>();
+        assert_eq!(config.0, 0x00000);
+        assert!(!config.is_uart_enabled::<0>());
+
+        config = config.enable_uart::<1>();
+        assert_eq!(config.0, 0x20000);
+        assert!(config.is_uart_enabled::<1>());
+
+        config = config.disable_uart::<1>();
+        assert_eq!(config.0, 0x00000);
+        assert!(!config.is_uart_enabled::<1>());
+
+        config = config.enable_uart::<2>();
+        assert_eq!(config.0, 0x4000000);
+        assert!(config.is_uart_enabled::<2>());
+
+        config = config.disable_uart::<2>();
+        assert_eq!(config.0, 0x0000000);
+        assert!(!config.is_uart_enabled::<2>());
+
+        config = config.enable_i2c();
+        assert_eq!(config.0, 0x80000);
+        assert!(config.is_i2c_enabled());
+
+        config = config.disable_i2c();
+        assert_eq!(config.0, 0x00000);
+        assert!(!config.is_i2c_enabled());
+
+        config = config.enable_pwm();
+        assert_eq!(config.0, 0x100000);
+        assert!(config.is_pwm_enabled());
+
+        config = config.disable_pwm();
+        assert_eq!(config.0, 0x000000);
+        assert!(!config.is_pwm_enabled());
+
+        config = config.enable_lz4d();
+        assert_eq!(config.0, 0x20000000);
+        assert!(config.is_lz4d_enabled());
+
+        config = config.disable_lz4d();
+        assert_eq!(config.0, 0x00000000);
+        assert!(!config.is_lz4d_enabled());
+    }
+}
+
+#[test]
+fn struct_ldo12uhs_config_functions() {
+    let mut config = Ldo12uhsConfig(0x0);
+
+    config = config.power_up();
+    assert_eq!(config.0, 0x1);
+    assert!(config.is_powered_up());
+
+    config = config.power_down();
+    assert_eq!(config.0, 0x0);
+    assert!(!config.is_powered_up());
+
+    config = config.set_output_voltage(0x5);
+    assert_eq!(config.0, 0x500000);
+    assert_eq!(config.get_output_voltage(), 0x5);
 }

--- a/bouffalo-rt/examples/blinky-bl616/Cargo.toml
+++ b/bouffalo-rt/examples/blinky-bl616/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 bouffalo-rt = { version = "0.0.0", path = "../..", features = ["bl616"] }
 embedded-hal = "1.0.0"
 panic-halt = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "blinky-bl616"

--- a/bouffalo-rt/examples/blinky-bl808/Cargo.toml
+++ b/bouffalo-rt/examples/blinky-bl808/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 bouffalo-rt = { path = "../.." }
 embedded-hal = "1.0.0"
 panic-halt = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [features]
 default = ["bl808-dsp"]

--- a/examples/multicore/multicore-demo/dsp/Cargo.toml
+++ b/examples/multicore/multicore-demo/dsp/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 bouffalo-hal = { path = "../../../../bouffalo-hal", features = ["bl808"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [dependencies.bouffalo-rt]
 path = "../../../../bouffalo-rt"

--- a/examples/multicore/multicore-demo/mcu/Cargo.toml
+++ b/examples/multicore/multicore-demo/mcu/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 [dependencies]
 bouffalo-hal = { path = "../../../../bouffalo-hal", features = ["bl808"] }
 panic-halt = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [dependencies.bouffalo-rt]
 path = "../../../../bouffalo-rt"

--- a/examples/peripherals/gpio-demo/Cargo.toml
+++ b/examples/peripherals/gpio-demo/Cargo.toml
@@ -11,7 +11,7 @@ bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-hal = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "gpio-demo"

--- a/examples/peripherals/i2c-demo/Cargo.toml
+++ b/examples/peripherals/i2c-demo/Cargo.toml
@@ -11,7 +11,7 @@ bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "i2c-demo"

--- a/examples/peripherals/jtag-demo/Cargo.toml
+++ b/examples/peripherals/jtag-demo/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "jtag-demo"

--- a/examples/peripherals/lz4d-demo/Cargo.toml
+++ b/examples/peripherals/lz4d-demo/Cargo.toml
@@ -12,7 +12,7 @@ bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-hal = "1.0.0"
 embedded-time = "0.12.1"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "lz4d-demo"

--- a/examples/peripherals/pwm-demo/Cargo.toml
+++ b/examples/peripherals/pwm-demo/Cargo.toml
@@ -11,7 +11,7 @@ bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "pwm-demo"

--- a/examples/peripherals/sdcard-demo/Cargo.toml
+++ b/examples/peripherals/sdcard-demo/Cargo.toml
@@ -12,7 +12,7 @@ bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 embedded-sdmmc = "0.8.1"
 
 [[bin]]

--- a/examples/peripherals/sdcard-gpt-demo/Cargo.toml
+++ b/examples/peripherals/sdcard-gpt-demo/Cargo.toml
@@ -12,7 +12,7 @@ bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 embedded-sdmmc = "0.8.1"
 gpt_disk_io = "0.16.0"
 gpt_disk_types = "0.16.0"

--- a/examples/peripherals/sdh-demo/Cargo.toml
+++ b/examples/peripherals/sdh-demo/Cargo.toml
@@ -14,7 +14,7 @@ embedded-time = "0.12.1"
 embedded-io = "0.6.1"
 embedded-sdmmc = "0.8.1"
 embedded-hal = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "sdh-demo"

--- a/examples/peripherals/spi-demo/Cargo.toml
+++ b/examples/peripherals/spi-demo/Cargo.toml
@@ -12,7 +12,7 @@ bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
-riscv = "0.12.1"
+riscv = "0.13.0"
 display-interface-spi = "0.5.0"
 mipidsi = "0.8.0"
 embedded-graphics = "0.8.1"

--- a/examples/peripherals/uart-async-demo/Cargo.toml
+++ b/examples/peripherals/uart-async-demo/Cargo.toml
@@ -11,7 +11,7 @@ bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
 bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
 panic-halt = "1.0.0"
 embedded-time = "0.12.1"
-riscv = "0.12.1"
+riscv = "0.13.0"
 
 [[bin]]
 name = "uart-async-demo"


### PR DESCRIPTION
- Update the riscv dependency from version 0.12.1 to 0.13.0.
- Add unit tests for ParamConfig, ClockConfig1, and Ldo12uhsConfig.