### PR TITLE
feat(sdio): add dma support for sdh reading blocks and imporve code style

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -35,16 +35,34 @@ jobs:
       - name: Run tests
         run: cargo test -p ${{ MATRIX.PACKAGE }}
 
-  build-bouffalo-hal:
-    name: Build
+  build-bouffalo-hal-riscv64:
+    name: Build for risv64
     needs: fmt
     runs-on: ubuntu-latest
     strategy:
       matrix:
         TARGET: [riscv64imac-unknown-none-elf]
         TOOLCHAIN: [nightly]
-        EXAMPLES: [gpio-demo, i2c-demo, jtag-demo, lz4d-demo, pwm-demo, 
-          sdcard-demo, sdcard-gpt-demo, spi-demo, uart-demo, uart-async-demo, uart-cli-demo, uart-dma-demo]
+        EXAMPLES: [gpio-demo, i2c-demo, jtag-demo, lz4d-demo, psram-demo, pwm-demo, 
+          sdcard-demo, sdcard-gpt-demo, sdh-demo, sdh-dma-demo, spi-demo, uart-demo, uart-async-demo, uart-cli-demo]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ MATRIX.TARGET }}
+          toolchain: ${{ MATRIX.TOOLCHAIN }}
+      - name: Run build
+        run: cargo build --target ${{ MATRIX.TARGET }} --release -p ${{ MATRIX.EXAMPLES }}
+
+  build-bouffalo-hal-riscv32:
+    name: Build for riscv32
+    needs: fmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        TARGET: [riscv32imac-unknown-none-elf]
+        TOOLCHAIN: [nightly]
+        EXAMPLES: [uart-dma-demo]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo test -p ${{ MATRIX.PACKAGE }}
 
   build-bouffalo-hal-riscv64:
-    name: Build for risv64
+    name: Build for riscv64
     needs: fmt
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ members = [
     "examples/peripherals/sdcard-gpt-demo",
     "examples/peripherals/psram-demo",
     "examples/peripherals/sdh-demo",
+    "examples/peripherals/sdh-dma-demo",
 ]
 resolver = "2"

--- a/bouffalo-hal/src/dma.rs
+++ b/bouffalo-hal/src/dma.rs
@@ -463,6 +463,7 @@ pub struct ChannelConfig(u32);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum DmaMode {
     /// Memory to memory (DMA).
+    /// Notice: When the DMA mode is set to memory to memory, the source and destination address must be incremented.
     Mem2Mem,
     /// Peripheral to memory (DMA).
     Mem2Periph,

--- a/bouffalo-hal/src/glb/v2.rs
+++ b/bouffalo-hal/src/glb/v2.rs
@@ -488,7 +488,7 @@ impl ClockConfig1 {
     const UART2: u32 = 0x1 << 26;
     const LZ4D: u32 = 0x1 << 29;
 
-    /// Enable clock gate for Direct Memory Access controller 0.
+    /// Enable clock gate for Direct Memory Access controller.
     #[inline]
     pub const fn enable_dma<const I: usize>(self) -> Self {
         match I {
@@ -498,7 +498,7 @@ impl ClockConfig1 {
             _ => unreachable!(),
         }
     }
-    /// Disable clock gate for Direct Memory Access controller 0.
+    /// Disable clock gate for Direct Memory Access controller.
     #[inline]
     pub const fn disable_dma<const I: usize>(self) -> Self {
         match I {
@@ -508,7 +508,7 @@ impl ClockConfig1 {
             _ => unreachable!(),
         }
     }
-    /// Check if clock gate for Direct Memory Access controller 0 is enabled.
+    /// Check if clock gate for Direct Memory Access controller is enabled.
     #[inline]
     pub const fn is_dma_enabled<const I: usize>(self) -> bool {
         match I {

--- a/bouffalo-rt/src/soc/bl616.rs
+++ b/bouffalo-rt/src/soc/bl616.rs
@@ -1,7 +1,6 @@
 //! BL616/BL618 single-core Wi-Fi 6, Bluetooth 5.3, Zigbee AIoT system-on-chip.
 
 use crate::{HalBasicConfig, HalFlashConfig, HalPatchCfg};
-use core::ops::Deref;
 
 #[cfg(all(feature = "bl616", target_arch = "riscv32"))]
 #[naked]

--- a/bouffalo-rt/src/soc/bl702.rs
+++ b/bouffalo-rt/src/soc/bl702.rs
@@ -9,7 +9,6 @@ use crate::arch::rvi::Stack;
 
 #[cfg(feature = "bl702")]
 use core::arch::naked_asm;
-use core::ops::Deref;
 
 #[cfg(feature = "bl702")]
 const LEN_STACK: usize = 1 * 1024;

--- a/bouffalo-rt/src/soc/bl808.rs
+++ b/bouffalo-rt/src/soc/bl808.rs
@@ -1,7 +1,6 @@
 //! BL808 tri-core heterogeneous Wi-Fi 802.11b/g/n, Bluetooth 5, Zigbee AIoT system-on-chip.
 
 use crate::{HalBasicConfig, HalFlashConfig, HalPatchCfg};
-use core::ops::Deref;
 
 #[cfg(all(feature = "bl808-mcu", target_arch = "riscv32"))]
 #[naked]

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,5 +10,10 @@
 | `pwm-demo`        | √     |
 | `sdcard-demo`     | √     |
 | `sdcard-gpt-demo` | √     |
+| `sdh-demo`     | √     |
+| `sdh-dma-demo` | √     |
 | `spi-demo`        | √     |
+| `uart-async-demo`       | √     |
+| `uart-cli-demo`       | √     |
 | `uart-demo`       | √     |
+| `uart-dma-demo`       | √     |

--- a/examples/peripherals/sdh-dma-demo/Cargo.toml
+++ b/examples/peripherals/sdh-dma-demo/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "sdh-dma-demo"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
+bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
+panic-halt = "1.0.0"
+embedded-time = "0.12.1"
+embedded-io = "0.6.1"
+embedded-sdmmc = "0.8.1"
+embedded-hal = "1.0.0"
+riscv = "0.13.0"
+
+[[bin]]
+name = "sdh-dma-demo"
+test = false

--- a/examples/peripherals/sdh-dma-demo/README.md
+++ b/examples/peripherals/sdh-dma-demo/README.md
@@ -1,0 +1,8 @@
+# SDH demo
+
+Build this example with:
+
+```
+rustup target install riscv64imac-unknown-none-elf
+cargo build --target riscv64imac-unknown-none-elf --release -p sdh-dma-demo
+```

--- a/examples/peripherals/sdh-dma-demo/build.rs
+++ b/examples/peripherals/sdh-dma-demo/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tbouffalo-rt.ld");
+}

--- a/examples/peripherals/uart-dma-demo/src/main.rs
+++ b/examples/peripherals/uart-dma-demo/src/main.rs
@@ -28,7 +28,7 @@ fn main(p: Peripherals, c: Clocks) -> ! {
         src_transfer_width: TransferWidth::Byte,
         dst_transfer_width: TransferWidth::Byte,
     };
-    let dma0_ch0 = Dma::new::<0>(p.dma0, 0, tx_config, &p.glb);
+    let dma0_ch0 = Dma::new(&p.dma0, Dma0Channel0, tx_config, &p.glb);
     let tx_lli_pool = &mut [LliPool::new(); 1];
     let hello = b"Welcome to Universal Asynchronous Receiver/Transmitter with Direct Memory Access demo!\r\nHello world!";
     let hello_ptr = hello.as_ptr();
@@ -48,9 +48,13 @@ fn main(p: Peripherals, c: Clocks) -> ! {
         }
     }
     dma0_ch0.start();
-    // TODO: use interrupt or check transfer status to know when DMA transfer is done.
+    // TODO: use interrupt to know when DMA transfer is done.
     // Wait for transfer to complete.
-    riscv::asm::delay(500_000);
+    while dma0_ch0.is_busy() {
+        core::hint::spin_loop();
+    }
+
+    dma0_ch0.stop();
 
     loop {
         led.set_low().ok();


### PR DESCRIPTION
- Add new example `sdh-dma-demo`.
- Use obtaining the register status to replace software delays for dma transmittion.
- Refacter `Dma` and `Sdh` structure.
- Split the workflow into two different architectures: riscv32 and riscv64.