### PR TITLE
feat(blri): add run command in blri, use blri as project runner

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 blri = "run --package blri --release --"
+
+[target.'cfg(target_os = "none")']
+runner = "cargo blri run"


### PR DESCRIPTION
Such as, build PWM demo with: 
`cargo run --target riscv64imac-unknown-none-elf --release -p pwm-demo -- --port COM13`
Also, if we get the efl_file, the following command is equivalent to running the elf2bin patch and flash commands.
`cargo blri run ./target/riscv64imac-unknown-none-elf/release/pwm-demo -p COM13`