### PR TITLE
fix(dma): update memory fence with `Ordering::SeqCst`

### DIFF
--- a/bouffalo-hal/src/sdio/dma_sdh.rs
+++ b/bouffalo-hal/src/sdio/dma_sdh.rs
@@ -151,7 +151,7 @@ impl<'a, SDH: Deref<Target = RegisterBlock>, PADS, CH: Deref<Target = UntypedCha
             self.dma_channel.stop();
 
             // FIXME modify to a proper fence
-            fence(Ordering::AcqRel);
+            fence(Ordering::SeqCst);
 
             block[j * 4 + 0] = val[0];
             block[j * 4 + 1] = val[1];


### PR DESCRIPTION
- `Ordering::SeqCst`: conforms to strict sequential consistency in memory access.

Refs: https://github.com/rustsbi/bouffalo-hal/pull/41#issuecomment-2799860760

Tested on m1s dock board with `sdh-dma-demo`, it works well.

<img width="497" alt="21bfab5683894080849ef9591b20a64" src="https://github.com/user-attachments/assets/3736b99e-73bc-4b64-aa2a-e33613eba41f" />
