### PR TITLE
feat(hal): flexible pads, rearrange peripherals to use flexible pads

### DIFF
--- a/bouffalo-hal/src/gpio/flex_pad.rs
+++ b/bouffalo-hal/src/gpio/flex_pad.rs
@@ -1,6 +1,8 @@
+use crate::gpio::{
+    Alternate,
+    typestate::{I2c, Spi},
+};
 use core::marker::PhantomData;
-
-use crate::gpio::{Alternate, typestate::Spi};
 
 pub struct FlexPad<'a> {
     _base: PhantomData<&'a super::AnyRegisterBlock>,
@@ -9,6 +11,11 @@ pub struct FlexPad<'a> {
 impl<'a> FlexPad<'a> {
     #[inline]
     pub fn from_spi<const N: usize, const F: usize>(pad: Alternate<'a, N, Spi<F>>) -> Self {
+        let _ = pad;
+        Self { _base: PhantomData }
+    }
+    #[inline]
+    pub fn from_i2c<const N: usize, const F: usize>(pad: Alternate<'a, N, I2c<F>>) -> Self {
         let _ = pad;
         Self { _base: PhantomData }
     }

--- a/bouffalo-hal/src/gpio/flex_pad.rs
+++ b/bouffalo-hal/src/gpio/flex_pad.rs
@@ -1,0 +1,15 @@
+use core::marker::PhantomData;
+
+use crate::gpio::{Alternate, typestate::Spi};
+
+pub struct FlexPad<'a> {
+    _base: PhantomData<&'a super::AnyRegisterBlock>,
+}
+
+impl<'a> FlexPad<'a> {
+    #[inline]
+    pub fn from_spi<const N: usize, const F: usize>(pad: Alternate<'a, N, Spi<F>>) -> Self {
+        let _ = pad;
+        Self { _base: PhantomData }
+    }
+}

--- a/bouffalo-hal/src/gpio/mod.rs
+++ b/bouffalo-hal/src/gpio/mod.rs
@@ -125,6 +125,7 @@
 
 mod alternate;
 mod convert;
+mod flex_pad;
 mod input;
 mod output;
 pub mod pad_v1;
@@ -135,7 +136,7 @@ use crate::glb::Version;
 pub use convert::{IntoPad, IntoPadv2};
 pub use typestate::*;
 
-pub use {alternate::Alternate, input::Input, output::Output};
+pub use {alternate::Alternate, flex_pad::FlexPad, input::Input, output::Output};
 
 /// Peripheral instance of a GPIO pad.
 pub trait Instance<'a> {

--- a/bouffalo-hal/src/i2c/blocking.rs
+++ b/bouffalo-hal/src/i2c/blocking.rs
@@ -1,0 +1,149 @@
+use super::{Error, SclPin, SdaPin, register::*};
+use crate::glb::{self, v2::I2cClockSource};
+use core::ops::Deref;
+
+/// Managed Inter-Integrated Circuit peripheral.
+pub struct I2c<I2C, PADS> {
+    i2c: I2C,
+    pads: PADS,
+}
+
+impl<I2C: Deref<Target = RegisterBlock>, SCL, SDA> I2c<I2C, (SCL, SDA)> {
+    /// Create a new Inter-Integrated Circuit instance.
+    #[inline]
+    pub fn new<const I: usize>(i2c: I2C, pads: (SCL, SDA), glb: &glb::v2::RegisterBlock) -> Self
+    where
+        SCL: SclPin<I>,
+        SDA: SdaPin<I>,
+    {
+        // TODO: support custom clock and frequency
+        // Enable clock
+        unsafe {
+            glb.i2c_config.modify(|config| {
+                config
+                    .enable_clock()
+                    .set_clock_source(I2cClockSource::Xclk)
+                    .set_clock_divide(0xff)
+            });
+            glb.clock_config_1.modify(|config| config.enable_i2c());
+            i2c.period_start.write(
+                PeriodStart(0)
+                    .set_phase(0, 0xff)
+                    .set_phase(1, 0xff)
+                    .set_phase(2, 0xff)
+                    .set_phase(3, 0xff),
+            );
+            i2c.period_stop.write(
+                PeriodStop(0)
+                    .set_phase(0, 0xff)
+                    .set_phase(1, 0xff)
+                    .set_phase(2, 0xff)
+                    .set_phase(3, 0xff),
+            );
+            i2c.period_data.write(
+                PeriodData(0)
+                    .set_phase(0, 0xff)
+                    .set_phase(1, 0xff)
+                    .set_phase(2, 0xff)
+                    .set_phase(3, 0xff),
+            );
+            i2c.config.write(
+                Config(0)
+                    .disable_ten_bit_address()
+                    .disable_scl_sync()
+                    .disable_sub_address(),
+            );
+        }
+
+        Self { i2c, pads }
+    }
+
+    /// Release the I2C instance and return the pads.
+    #[inline]
+    pub fn free(self, glb: &glb::v2::RegisterBlock) -> (I2C, (SCL, SDA)) {
+        unsafe {
+            glb.i2c_config.modify(|config| config.disable_clock());
+            glb.clock_config_1.modify(|config| config.disable_i2c());
+        }
+        (self.i2c, self.pads)
+    }
+
+    /// Enable sub-address.
+    #[inline]
+    pub fn enable_sub_address(&mut self, sub_address: u8) {
+        // TODO: support sub-address with more than one byte
+        unsafe {
+            self.i2c.config.modify(|config| {
+                config
+                    .enable_sub_address()
+                    .set_sub_address_byte_count(SubAddressByteCount::One)
+            });
+            self.i2c.sub_address.write(sub_address as u32);
+        }
+    }
+
+    /// Disable sub-address.
+    #[inline]
+    pub fn disable_sub_address(&mut self) {
+        unsafe {
+            self.i2c
+                .config
+                .modify(|config| config.disable_sub_address());
+        }
+    }
+}
+
+impl<I2C: Deref<Target = RegisterBlock>, PADS> embedded_hal::i2c::ErrorType for I2c<I2C, PADS> {
+    type Error = Error;
+}
+
+impl<I2C: Deref<Target = RegisterBlock>, PADS> embedded_hal::i2c::I2c for I2c<I2C, PADS> {
+    #[inline]
+    fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        for op in operations {
+            match op {
+                embedded_hal::i2c::Operation::Write(_bytes) => {
+                    todo!()
+                }
+                embedded_hal::i2c::Operation::Read(bytes) => {
+                    let len = bytes.len() as u8;
+                    unsafe {
+                        self.i2c.config.modify(|config| {
+                            config
+                                .set_read_direction()
+                                .set_slave_address(address as u16)
+                                .set_packet_length(len - 1)
+                                .enable_master()
+                        })
+                    };
+
+                    let mut i = 0;
+                    let max_retry = len * 100;
+                    let mut retry = 0;
+                    while i < len {
+                        while self.i2c.fifo_config_1.read().receive_available_bytes() == 0 {
+                            retry += 1;
+                            if retry >= max_retry {
+                                unsafe { self.i2c.config.modify(|config| config.disable_master()) };
+                                return Err(Error::Other);
+                            }
+                        }
+                        let word = self.i2c.fifo_read.read();
+                        let bytes_to_read = core::cmp::min(len - i, 4);
+                        for j in 0..bytes_to_read {
+                            bytes[i as usize] = (word >> (j * 8)) as u8;
+                            i += 1;
+                        }
+                    }
+
+                    unsafe { self.i2c.config.modify(|config| config.disable_master()) };
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/bouffalo-hal/src/i2c/mod.rs
+++ b/bouffalo-hal/src/i2c/mod.rs
@@ -1,0 +1,25 @@
+//! Inter-Integrated Circuit bus.
+
+mod blocking;
+mod pads;
+mod register;
+pub use blocking::I2c;
+pub use pads::{SclPin, SdaPin};
+pub use register::*;
+
+/// I2C error.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    Other,
+}
+
+impl embedded_hal::i2c::Error for Error {
+    #[inline(always)]
+    fn kind(&self) -> embedded_hal::i2c::ErrorKind {
+        use embedded_hal::i2c::ErrorKind;
+        match self {
+            Error::Other => ErrorKind::Other,
+        }
+    }
+}

--- a/bouffalo-hal/src/i2c/mod.rs
+++ b/bouffalo-hal/src/i2c/mod.rs
@@ -4,7 +4,7 @@ mod blocking;
 mod pads;
 mod register;
 pub use blocking::I2c;
-pub use pads::{SclPin, SdaPin};
+pub use pads::{IntoI2cScl, IntoI2cSda, IntoPads};
 pub use register::*;
 
 /// I2C error.
@@ -23,3 +23,12 @@ impl embedded_hal::i2c::Error for Error {
         }
     }
 }
+
+/// Peripheral instance for I2C.
+pub trait Instance<'a> {
+    /// Retrieve register block from this instance.
+    fn register_block(self) -> &'a RegisterBlock;
+}
+
+/// I2C peripheral instance with a number.
+pub trait Numbered<'a, const N: usize>: Instance<'a> {}

--- a/bouffalo-hal/src/i2c/pads.rs
+++ b/bouffalo-hal/src/i2c/pads.rs
@@ -1,0 +1,43 @@
+pub trait SclPin<const I: usize> {}
+
+pub trait SdaPin<const I: usize> {}
+
+#[rustfmt::skip]
+mod i2c_impls {
+    use crate::gpio::{self, Alternate};
+    use super::{SclPin, SdaPin};
+
+    // 0, 2, 4, ..., 2n: SCL
+    // 1, 3, 5, ..., 2n+1: SDA
+    // TODO: support other pads if needed
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 0, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 1, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 2, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 3, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 4, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 5, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 6, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 7, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 8, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 9, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 10, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 11, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 12, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 13, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 14, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 15, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 16, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 17, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 18, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 19, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 20, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 21, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 22, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 23, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 24, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 25, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 26, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 27, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 28, gpio::I2c<I>> {}
+    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 29, gpio::I2c<I>> {}
+}

--- a/bouffalo-hal/src/i2c/pads.rs
+++ b/bouffalo-hal/src/i2c/pads.rs
@@ -1,43 +1,32 @@
-pub trait SclPin<const I: usize> {}
+use crate::gpio::FlexPad;
 
-pub trait SdaPin<const I: usize> {}
+/// Pad that can be configured into I2C SCL alternate function.
+pub trait IntoI2cScl<'a, const I: usize> {
+    /// Configure this pad into I2C SCL signal.
+    fn into_i2c_scl(self) -> FlexPad<'a>;
+}
 
-#[rustfmt::skip]
-mod i2c_impls {
-    use crate::gpio::{self, Alternate};
-    use super::{SclPin, SdaPin};
+/// Pad that can be configured into I2C SDA alternate function.
+pub trait IntoI2cSda<'a, const I: usize> {
+    /// Configure this pad into I2C SDA signal.
+    fn into_i2c_sda(self) -> FlexPad<'a>;
+}
 
-    // 0, 2, 4, ..., 2n: SCL
-    // 1, 3, 5, ..., 2n+1: SDA
-    // TODO: support other pads if needed
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 0, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 1, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 2, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 3, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 4, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 5, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 6, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 7, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 8, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 9, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 10, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 11, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 12, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 13, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 14, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 15, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 16, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 17, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 18, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 19, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 20, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 21, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 22, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 23, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 24, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 25, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 26, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 27, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SclPin<I> for Alternate<'a, 28, gpio::I2c<I>> {}
-    impl<'a, const I: usize> SdaPin<I> for Alternate<'a, 29, gpio::I2c<I>> {}
+/// Pads that can be converted into valid I2C pads.
+pub trait IntoPads<'a, const I: usize> {
+    /// Convert this set of pad into I2C alternate function.
+    fn into_i2c_pads(self) -> (FlexPad<'a>, FlexPad<'a>);
+}
+
+impl<'a, A, B, const I: usize> IntoPads<'a, I> for (A, B)
+where
+    A: IntoI2cScl<'a, I>,
+    B: IntoI2cSda<'a, I>,
+{
+    #[inline]
+    fn into_i2c_pads(self) -> (FlexPad<'a>, FlexPad<'a>) {
+        let a = self.0.into_i2c_scl();
+        let b = self.1.into_i2c_sda();
+        (a, b)
+    }
 }

--- a/bouffalo-hal/src/spi.rs
+++ b/bouffalo-hal/src/spi.rs
@@ -5,7 +5,7 @@ mod pads;
 mod register;
 
 pub use master::Spi;
-pub use pads::Pads;
+pub use pads::{IntoPads, IntoSpiClkSignal, IntoSpiCsSignal, IntoSpiMisoSignal, IntoSpiMosiSignal};
 pub use register::*;
 
 /// SPI error.
@@ -30,3 +30,6 @@ pub trait Instance<'a> {
     /// Retrieve register block from this instance.
     fn register_block(self) -> &'a RegisterBlock;
 }
+
+/// SPI peripheral instance with a number.
+pub trait Numbered<'a, const N: usize>: Instance<'a> {}

--- a/bouffalo-hal/src/spi/mod.rs
+++ b/bouffalo-hal/src/spi/mod.rs
@@ -5,7 +5,7 @@ mod pads;
 mod register;
 
 pub use master::Spi;
-pub use pads::{IntoPads, IntoSpiClkSignal, IntoSpiCsSignal, IntoSpiMisoSignal, IntoSpiMosiSignal};
+pub use pads::{IntoPads, IntoSpiClk, IntoSpiCs, IntoSpiMiso, IntoSpiMosi, IntoTransmitOnly};
 pub use register::*;
 
 /// SPI error.

--- a/bouffalo-hal/src/spi/pads.rs
+++ b/bouffalo-hal/src/spi/pads.rs
@@ -8,17 +8,17 @@ pub trait IntoPads<'a, const I: usize> {
 
 impl<'a, A, B, C, D, const I: usize> IntoPads<'a, I> for (A, B, C, D)
 where
-    A: IntoSpiClkSignal<'a, I>,
-    B: IntoSpiMosiSignal<'a, I>,
-    C: IntoSpiMisoSignal<'a, I>,
-    D: IntoSpiCsSignal<'a, I>,
+    A: IntoSpiClk<'a, I>,
+    B: IntoSpiMosi<'a, I>,
+    C: IntoSpiMiso<'a, I>,
+    D: IntoSpiCs<'a, I>,
 {
     #[inline]
     fn into_full_duplex_pads(self) -> (FlexPad<'a>, FlexPad<'a>, FlexPad<'a>, FlexPad<'a>) {
-        let a = self.0.into_spi_clk_signal();
-        let b = self.1.into_spi_mosi_signal();
-        let c = self.2.into_spi_miso_signal();
-        let d = self.3.into_spi_cs_signal();
+        let a = self.0.into_spi_clk();
+        let b = self.1.into_spi_mosi();
+        let c = self.2.into_spi_miso();
+        let d = self.3.into_spi_cs();
         (a, b, c, d)
     }
 }
@@ -31,39 +31,39 @@ pub trait IntoTransmitOnly<'a, const I: usize> {
 
 impl<'a, A, B, C, const I: usize> IntoTransmitOnly<'a, I> for (A, B, C)
 where
-    A: IntoSpiClkSignal<'a, I>,
-    B: IntoSpiMosiSignal<'a, I>,
-    C: IntoSpiCsSignal<'a, I>,
+    A: IntoSpiClk<'a, I>,
+    B: IntoSpiMosi<'a, I>,
+    C: IntoSpiCs<'a, I>,
 {
     #[inline]
     fn into_transmit_only_pads(self) -> (FlexPad<'a>, FlexPad<'a>, FlexPad<'a>) {
-        let a = self.0.into_spi_clk_signal();
-        let b = self.1.into_spi_mosi_signal();
-        let c = self.2.into_spi_cs_signal();
+        let a = self.0.into_spi_clk();
+        let b = self.1.into_spi_mosi();
+        let c = self.2.into_spi_cs();
         (a, b, c)
     }
 }
 
 /// Pad that can be configured into SPI clock alternate function.
-pub trait IntoSpiClkSignal<'a, const I: usize> {
+pub trait IntoSpiClk<'a, const I: usize> {
     /// Configure this pad into SPI clock signal.
-    fn into_spi_clk_signal(self) -> FlexPad<'a>;
+    fn into_spi_clk(self) -> FlexPad<'a>;
 }
 
 /// Pad that can be configured into SPI MOSI alternate function.
-pub trait IntoSpiMosiSignal<'a, const I: usize> {
+pub trait IntoSpiMosi<'a, const I: usize> {
     /// Configure this pad into SPI MOSI signal.
-    fn into_spi_mosi_signal(self) -> FlexPad<'a>;
+    fn into_spi_mosi(self) -> FlexPad<'a>;
 }
 
 /// Pad that can be configured into SPI MISO alternate function.
-pub trait IntoSpiMisoSignal<'a, const I: usize> {
+pub trait IntoSpiMiso<'a, const I: usize> {
     /// Configure this pad into SPI MISO signal.
-    fn into_spi_miso_signal(self) -> FlexPad<'a>;
+    fn into_spi_miso(self) -> FlexPad<'a>;
 }
 
 /// Pad that can be configured into SPI chip select alternate function.
-pub trait IntoSpiCsSignal<'a, const I: usize> {
+pub trait IntoSpiCs<'a, const I: usize> {
     /// Configure this pad into SPI chip select signal.
-    fn into_spi_cs_signal(self) -> FlexPad<'a>;
+    fn into_spi_cs(self) -> FlexPad<'a>;
 }

--- a/bouffalo-rt/src/macros.rs
+++ b/bouffalo-rt/src/macros.rs
@@ -174,6 +174,28 @@ impl<'a> bouffalo_hal::spi::Numbered<'a, $i> for &'a mut $SPIx {}
     };
 }
 
+macro_rules! i2c {
+    ($($I2Ci: ty: $i: expr,)+) => {
+    $(
+impl bouffalo_hal::i2c::Instance<'static> for $I2Ci {
+    #[inline]
+    fn register_block(self) -> &'static bouffalo_hal::i2c::RegisterBlock {
+        unsafe { &*Self::ptr() }
+    }
+}
+impl bouffalo_hal::i2c::Numbered<'static, $i> for $I2Ci {}
+
+impl<'a> bouffalo_hal::i2c::Instance<'a> for &'a mut $I2Ci {
+    #[inline]
+    fn register_block(self) -> &'a bouffalo_hal::i2c::RegisterBlock {
+        &*self
+    }
+}
+impl<'a> bouffalo_hal::i2c::Numbered<'a, $i> for &'a mut $I2Ci {}
+    )+
+    };
+}
+
 macro_rules! pwm {
     ($($PWMx: ty,)+) => {
     $(
@@ -559,6 +581,31 @@ impl<'a> $Trait<'a, $I_spi> for &'a mut $Pad<$N_pad> {
     #[inline]
     fn $into_spi_signal(self) -> FlexPad<'a> {
         FlexPad::from_spi(Alternate::new_spi::<$I_spi>(self))
+    }
+}
+)+)+
+    };
+}
+
+macro_rules! pad_i2c {
+    (
+        $Pad: ident;
+        $(
+            ($($N_pad: expr,)+): $Trait: ident<$I_i2c: literal>, $into_i2c_signal: ident;
+        )+
+    ) => {
+$($(
+impl $Trait<'static, $I_i2c> for $Pad<$N_pad> {
+    #[inline]
+    fn $into_i2c_signal(self) -> FlexPad<'static> {
+        FlexPad::from_i2c(Alternate::new_i2c::<$I_i2c>(self))
+    }
+}
+
+impl<'a> $Trait<'a, $I_i2c> for &'a mut $Pad<$N_pad> {
+    #[inline]
+    fn $into_i2c_signal(self) -> FlexPad<'a> {
+        FlexPad::from_i2c(Alternate::new_i2c::<$I_i2c>(self))
     }
 }
 )+)+

--- a/bouffalo-rt/src/soc/bl702/peripheral.rs
+++ b/bouffalo-rt/src/soc/bl702/peripheral.rs
@@ -50,7 +50,7 @@ uart! {
     UART1: 1,
 }
 
-spi! { SPI, }
+spi! { SPI: 0, }
 
 pwm! { PWM, }
 

--- a/bouffalo-rt/src/soc/bl808/peripheral.rs
+++ b/bouffalo-rt/src/soc/bl808/peripheral.rs
@@ -2,7 +2,8 @@ pub use bouffalo_hal::clocks::Clocks;
 use bouffalo_hal::{
     dma::{EightChannels, FourChannels, Periph4Dma01, Periph4Dma2},
     gpio::{Alternate, FlexPad},
-    spi::{IntoSpiClkSignal, IntoSpiCsSignal, IntoSpiMisoSignal, IntoSpiMosiSignal},
+    i2c::{IntoI2cScl, IntoI2cSda},
+    spi::{IntoSpiClk, IntoSpiCs, IntoSpiMiso, IntoSpiMosi},
 };
 
 /// Peripherals available on ROM start.
@@ -110,14 +111,11 @@ dma! {
     DMA2: (2, EightChannels, Periph4Dma2),
 }
 
-uart! {
-    UART0: 0,
-    UART1: 1,
-    UART2: 2,
-    UART3: 3,
-}
+uart! { UART0: 0, UART1: 1, UART2: 2, UART3: 3, }
 
 spi! { SPI0: 0, SPI1: 1, }
+
+i2c! { I2C0: 0, I2C1: 1, I2C2: 2, I2C3: 3, }
 
 pwm! { PWM, }
 
@@ -130,14 +128,34 @@ impl_pad_v2! { Pad: GLBv2 }
 
 pad_spi! {
     Pad;
-    (3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43,     ): IntoSpiClkSignal<1>, into_spi_clk_signal;
-    (1, 5, 9,  13, 17, 21, 25, 29, 33, 37, 41, 45, ): IntoSpiMosiSignal<1>, into_spi_mosi_signal;
-    (2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42,     ): IntoSpiMisoSignal<1>, into_spi_miso_signal;
-    (0, 4, 8,  12, 16, 20, 24, 28, 32, 36, 40, 44, ): IntoSpiCsSignal<1>, into_spi_cs_signal;
-    (3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43,     ): IntoSpiClkSignal<0>, into_spi_clk_signal;
-    (1, 5, 9,  13, 17, 21, 25, 29, 33, 37, 41, 45, ): IntoSpiMosiSignal<0>, into_spi_mosi_signal;
-    (2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42,     ): IntoSpiMisoSignal<0>, into_spi_miso_signal;
-    (0, 4, 8,  12, 16, 20, 24, 28, 32, 36, 40, 44, ): IntoSpiCsSignal<0>, into_spi_cs_signal;
+    (3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43,     ): IntoSpiClk<1>, into_spi_clk;
+    (1, 5, 9,  13, 17, 21, 25, 29, 33, 37, 41, 45, ): IntoSpiMosi<1>, into_spi_mosi;
+    (2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42,     ): IntoSpiMiso<1>, into_spi_miso;
+    (0, 4, 8,  12, 16, 20, 24, 28, 32, 36, 40, 44, ): IntoSpiCs<1>, into_spi_cs;
+    (3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43,     ): IntoSpiClk<0>, into_spi_clk;
+    (1, 5, 9,  13, 17, 21, 25, 29, 33, 37, 41, 45, ): IntoSpiMosi<0>, into_spi_mosi;
+    (2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42,     ): IntoSpiMiso<0>, into_spi_miso;
+    (0, 4, 8,  12, 16, 20, 24, 28, 32, 36, 40, 44, ): IntoSpiCs<0>, into_spi_cs;
+}
+
+pad_i2c! {
+    Pad;
+    (0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,
+        24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44,): IntoI2cScl<0>, into_i2c_scl;
+    (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23,
+        25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45,): IntoI2cSda<0>, into_i2c_sda;
+    (0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,
+        24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44,): IntoI2cScl<1>, into_i2c_scl;
+    (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23,
+        25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45,): IntoI2cSda<1>, into_i2c_sda;
+    (0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,
+        24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44,): IntoI2cScl<2>, into_i2c_scl;
+    (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23,
+        25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45,): IntoI2cSda<2>, into_i2c_sda;
+    (0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,
+        24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44,): IntoI2cScl<3>, into_i2c_scl;
+    (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23,
+        25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45,): IntoI2cSda<3>, into_i2c_sda;
 }
 
 // Used by macros only.

--- a/bouffalo-rt/src/soc/bl808/peripheral.rs
+++ b/bouffalo-rt/src/soc/bl808/peripheral.rs
@@ -134,6 +134,10 @@ pad_spi! {
     (1, 5, 9,  13, 17, 21, 25, 29, 33, 37, 41, 45, ): IntoSpiMosiSignal<1>, into_spi_mosi_signal;
     (2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42,     ): IntoSpiMisoSignal<1>, into_spi_miso_signal;
     (0, 4, 8,  12, 16, 20, 24, 28, 32, 36, 40, 44, ): IntoSpiCsSignal<1>, into_spi_cs_signal;
+    (3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43,     ): IntoSpiClkSignal<0>, into_spi_clk_signal;
+    (1, 5, 9,  13, 17, 21, 25, 29, 33, 37, 41, 45, ): IntoSpiMosiSignal<0>, into_spi_mosi_signal;
+    (2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42,     ): IntoSpiMisoSignal<0>, into_spi_miso_signal;
+    (0, 4, 8,  12, 16, 20, 24, 28, 32, 36, 40, 44, ): IntoSpiCsSignal<0>, into_spi_cs_signal;
 }
 
 // Used by macros only.

--- a/bouffalo-rt/src/soc/bl808/peripheral.rs
+++ b/bouffalo-rt/src/soc/bl808/peripheral.rs
@@ -1,5 +1,9 @@
 pub use bouffalo_hal::clocks::Clocks;
-use bouffalo_hal::dma::{EightChannels, FourChannels, Periph4Dma01, Periph4Dma2};
+use bouffalo_hal::{
+    dma::{EightChannels, FourChannels, Periph4Dma01, Periph4Dma2},
+    gpio::{Alternate, FlexPad},
+    spi::{IntoSpiClkSignal, IntoSpiCsSignal, IntoSpiMisoSignal, IntoSpiMosiSignal},
+};
 
 /// Peripherals available on ROM start.
 pub struct Peripherals<'a> {
@@ -113,7 +117,7 @@ uart! {
     UART3: 3,
 }
 
-spi! { SPI0, SPI1, }
+spi! { SPI0: 0, SPI1: 1, }
 
 pwm! { PWM, }
 
@@ -123,6 +127,14 @@ pub struct Pad<const N: usize> {
 }
 
 impl_pad_v2! { Pad: GLBv2 }
+
+pad_spi! {
+    Pad;
+    (3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43,     ): IntoSpiClkSignal<1>, into_spi_clk_signal;
+    (1, 5, 9,  13, 17, 21, 25, 29, 33, 37, 41, 45, ): IntoSpiMosiSignal<1>, into_spi_mosi_signal;
+    (2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42,     ): IntoSpiMisoSignal<1>, into_spi_miso_signal;
+    (0, 4, 8,  12, 16, 20, 24, 28, 32, 36, 40, 44, ): IntoSpiCsSignal<1>, into_spi_cs_signal;
+}
 
 // Used by macros only.
 #[allow(unused)]

--- a/examples/peripherals/i2c-demo/src/main.rs
+++ b/examples/peripherals/i2c-demo/src/main.rs
@@ -21,8 +21,8 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
     let mut led = p.gpio.io8.into_floating_output();
 
-    let scl = p.gpio.io6.into_i2c::<0>();
-    let sda = p.gpio.io7.into_i2c::<0>();
+    let scl = p.gpio.io6;
+    let sda = p.gpio.io7;
     let mut i2c = I2c::new(p.i2c0, (scl, sda), &p.glb);
     i2c.enable_sub_address(SCREEN_TOUCH_SUB_ADDRESS);
 

--- a/examples/peripherals/sdcard-demo/src/main.rs
+++ b/examples/peripherals/sdcard-demo/src/main.rs
@@ -32,16 +32,12 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     let mut led = p.gpio.io8.into_floating_output();
     let mut led_state = PinState::High;
 
-    let spi_clk = p.gpio.io3.into_spi::<1>();
-    let spi_mosi = p.gpio.io1.into_spi::<1>();
-    let spi_miso = p.gpio.io2.into_spi::<1>();
-    let spi_cs = p.gpio.io0.into_spi::<1>();
-    let spi_sd = Spi::new(
-        p.spi1,
-        (spi_clk, spi_mosi, spi_miso, spi_cs),
-        MODE_3,
-        &p.glb,
-    );
+    let spi_clk = p.gpio.io3;
+    let spi_mosi = p.gpio.io1;
+    let spi_miso = p.gpio.io2;
+    let spi_cs = p.gpio.io0;
+    let pads = (spi_clk, spi_mosi, spi_miso, spi_cs);
+    let spi_sd = Spi::new(p.spi1, pads, MODE_3, &p.glb);
 
     let delay = riscv::delay::McycleDelay::new(40_000_000);
     let sdcard = SdCard::new(spi_sd, delay);

--- a/examples/peripherals/sdcard-gpt-demo/src/main.rs
+++ b/examples/peripherals/sdcard-gpt-demo/src/main.rs
@@ -202,17 +202,13 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     let mut led = p.gpio.io8.into_floating_output();
     let mut led_state = PinState::High;
 
-    let spi_clk = p.gpio.io3.into_spi::<1>();
-    let spi_mosi = p.gpio.io1.into_spi::<1>();
-    let spi_miso = p.gpio.io2.into_spi::<1>();
-    let spi_cs = p.gpio.io0.into_spi::<1>();
+    let spi_clk = p.gpio.io3;
+    let spi_mosi = p.gpio.io1;
+    let spi_miso = p.gpio.io2;
+    let spi_cs = p.gpio.io0;
+    let pads = (spi_clk, spi_mosi, spi_miso, spi_cs);
 
-    let spi_sd = Spi::new(
-        p.spi1,
-        (spi_clk, spi_mosi, spi_miso, spi_cs),
-        MODE_3,
-        &p.glb,
-    );
+    let spi_sd = Spi::new(p.spi1, pads, MODE_3, &p.glb);
 
     let delay = riscv::delay::McycleDelay::new(40_000_000);
     let sdcard = SdCard::new(spi_sd, delay);

--- a/examples/peripherals/spi-demo/Cargo.toml
+++ b/examples/peripherals/spi-demo/Cargo.toml
@@ -13,8 +13,7 @@ panic-halt = "1.0.0"
 embedded-time = "0.12.1"
 embedded-hal = "1.0.0"
 riscv = "0.13.0"
-display-interface-spi = "0.5.0"
-mipidsi = "0.8.0"
+mipidsi = "0.9.0"
 embedded-graphics = "0.8.1"
 
 [[bin]]

--- a/examples/peripherals/spi-demo/src/main.rs
+++ b/examples/peripherals/spi-demo/src/main.rs
@@ -12,8 +12,7 @@ use embedded_graphics::{
     text::Text,
 };
 use embedded_hal::spi::MODE_0;
-use mipidsi::Builder;
-use mipidsi::{models::ST7789, options::ColorInversion};
+use mipidsi::{Builder, interface::SpiInterface, models::ST7789, options::ColorInversion};
 use panic_halt as _;
 
 #[entry]
@@ -30,7 +29,8 @@ fn main(p: Peripherals, _c: Clocks) -> ! {
     let spi_lcd = Spi::transmit_only(p.spi1, (spi_clk, spi_mosi, spi_cs), MODE_0, &p.glb);
 
     let mut delay = riscv::delay::McycleDelay::new(40_000_000);
-    let di = display_interface_spi::SPIInterface::new(spi_lcd, lcd_dc);
+    let mut buffer = [0u8; 512];
+    let di = SpiInterface::new(spi_lcd, lcd_dc, &mut buffer);
 
     let mut display = Builder::new(ST7789, di)
         .invert_colors(ColorInversion::Inverted)

--- a/examples/peripherals/spi-demo/src/main.rs
+++ b/examples/peripherals/spi-demo/src/main.rs
@@ -21,13 +21,13 @@ fn main(p: Peripherals, _c: Clocks) -> ! {
     let mut led = p.gpio.io8.into_floating_output();
     let mut led_state = PinState::Low;
 
-    let spi_cs = p.gpio.io12.into_spi::<1>();
-    let spi_mosi = p.gpio.io25.into_spi::<1>();
-    let spi_clk = p.gpio.io19.into_spi::<1>();
+    let spi_cs = p.gpio.io12;
+    let spi_mosi = p.gpio.io25;
+    let spi_clk = p.gpio.io19;
     let lcd_dc = p.gpio.io13.into_floating_output();
     let mut lcd_bl = p.gpio.io11.into_floating_output();
     let lcd_rst = p.gpio.io24.into_floating_output();
-    let spi_lcd = Spi::new(p.spi1, (spi_clk, spi_mosi, spi_cs), MODE_0, &p.glb);
+    let spi_lcd = Spi::transmit_only(p.spi1, (spi_clk, spi_mosi, spi_cs), MODE_0, &p.glb);
 
     let mut delay = riscv::delay::McycleDelay::new(40_000_000);
     let di = display_interface_spi::SPIInterface::new(spi_lcd, lcd_dc);


### PR DESCRIPTION
Before:

```rust
    let spi_clk = p.gpio.io3.into_spi::<1>();
    let spi_mosi = p.gpio.io1.into_spi::<1>();
    let spi_miso = p.gpio.io2.into_spi::<1>();
    let spi_cs = p.gpio.io0.into_spi::<1>();
    let spi_sd = Spi::new(
        p.spi1,
        (spi_clk, spi_mosi, spi_miso, spi_cs),
        MODE_3,
        &p.glb,
    );
```

After:

```rust
    let spi_clk = p.gpio.io3;
    let spi_mosi = p.gpio.io1;
    let spi_miso = p.gpio.io2;
    let spi_cs = p.gpio.io0;

    let pads = (spi_clk, spi_mosi, spi_miso, spi_cs);
    let spi_sd = Spi::new(p.spi1, pads, MODE_3, &p.glb);
```