### PR TITLE
refactor(hal): simplify UART peripheral implementation using flexible pads

### DIFF
--- a/bouffalo-hal/src/gpio/flex_pad.rs
+++ b/bouffalo-hal/src/gpio/flex_pad.rs
@@ -1,5 +1,5 @@
 use crate::gpio::{
-    Alternate,
+    Alternate, Uart,
     typestate::{I2c, Spi},
 };
 use core::marker::PhantomData;
@@ -16,6 +16,11 @@ impl<'a> FlexPad<'a> {
     }
     #[inline]
     pub fn from_i2c<const N: usize, const F: usize>(pad: Alternate<'a, N, I2c<F>>) -> Self {
+        let _ = pad;
+        Self { _base: PhantomData }
+    }
+    #[inline]
+    pub fn from_uart<const N: usize>(pad: Alternate<'a, N, Uart>) -> Self {
         let _ = pad;
         Self { _base: PhantomData }
     }

--- a/bouffalo-hal/src/lib.rs
+++ b/bouffalo-hal/src/lib.rs
@@ -38,7 +38,7 @@ pub mod prelude {
     #[cfg(feature = "glb-v2")]
     pub use crate::gpio::IntoPadv2 as _;
     pub use crate::lz4d::Lz4dExt as _;
-    pub use crate::uart::UartExt as _;
+    pub use crate::uart::{IntoUartSignal as _, UartExt as _};
     pub use embedded_hal::digital::{InputPin as _, OutputPin as _, PinState};
     pub use embedded_hal::i2c::I2c as _;
     pub use embedded_hal::pwm::SetDutyCycle as _;

--- a/bouffalo-hal/src/uart/mod.rs
+++ b/bouffalo-hal/src/uart/mod.rs
@@ -15,28 +15,26 @@ mod blocking;
 pub use blocking::*;
 mod asynch;
 pub use asynch::*;
+mod signal;
+pub use signal::*;
 
 /// Extend constructor to owned UART register blocks.
-pub trait UartExt<'a, PADS, const I: usize> {
+pub trait UartExt<'a, const I: usize> {
     /// Creates a polling serial instance, without interrupt or DMA configurations.
     fn freerun(
         self,
         config: Config,
-        pads: PADS,
+        pads: impl IntoSignals<'a, I>,
         clocks: &Clocks,
-    ) -> Result<BlockingSerial<'a, PADS>, ConfigError>
-    where
-        PADS: Pads<I>;
+    ) -> Result<BlockingSerial<'a>, ConfigError>;
     /// Creates an interrupt driven async/await serial instance without DMA configurations.
     fn with_interrupt(
         self,
         config: Config,
-        pads: PADS,
+        pads: impl IntoSignals<'a, I>,
         clocks: &Clocks,
         state: &'static SerialState,
-    ) -> Result<AsyncSerial<'a, PADS>, ConfigError>
-    where
-        PADS: Pads<I>;
+    ) -> Result<AsyncSerial<'a>, ConfigError>;
 }
 
 /// Peripheral instance for UART.

--- a/bouffalo-hal/src/uart/mux.rs
+++ b/bouffalo-hal/src/uart/mux.rs
@@ -15,7 +15,7 @@ pub struct MuxRxd<const I: usize>;
 
 impl<const I: usize> MuxRts<I> {
     #[inline]
-    fn signal() -> UartSignal {
+    pub fn signal() -> UartSignal {
         match I {
             0 => UartSignal::Rts0,
             1 => UartSignal::Rts1,
@@ -27,7 +27,7 @@ impl<const I: usize> MuxRts<I> {
 
 impl<const I: usize> MuxCts<I> {
     #[inline]
-    fn signal() -> UartSignal {
+    pub fn signal() -> UartSignal {
         match I {
             0 => UartSignal::Cts0,
             1 => UartSignal::Cts1,
@@ -39,7 +39,7 @@ impl<const I: usize> MuxCts<I> {
 
 impl<const I: usize> MuxTxd<I> {
     #[inline]
-    fn signal() -> UartSignal {
+    pub fn signal() -> UartSignal {
         match I {
             0 => UartSignal::Txd0,
             1 => UartSignal::Txd1,
@@ -51,7 +51,7 @@ impl<const I: usize> MuxTxd<I> {
 
 impl<const I: usize> MuxRxd<I> {
     #[inline]
-    fn signal() -> UartSignal {
+    pub fn signal() -> UartSignal {
         match I {
             0 => UartSignal::Rxd0,
             1 => UartSignal::Rxd1,
@@ -160,6 +160,7 @@ impl<'a, const N: usize, M> UartMux<'a, N, M> {
         }
     }
 }
+
 impl<'a> UartMuxes<'a> {
     #[doc(hidden)]
     #[inline]

--- a/bouffalo-hal/src/uart/pad.rs
+++ b/bouffalo-hal/src/uart/pad.rs
@@ -1,323 +1,78 @@
-use super::{
-    BlockingReceiveHalf, BlockingTransmitHalf, MuxCts, MuxRts, MuxRxd, MuxTxd, RegisterBlock,
-    UartMux,
+use super::signal::{ClearToSend, Receive, RequestToSend, Transmit};
+use crate::{
+    gpio::{Alternate, FlexPad, MmUart},
+    uart::IntoSignals,
 };
-use crate::gpio::{Alternate, MmUart, Uart};
 
-/// Check if target gpio `Pin` is internally connected to UART signal index `I`.
-pub trait HasUartSignal<const I: usize> {}
-
-impl<'a> HasUartSignal<0> for Alternate<'a, 0, Uart> {}
-impl<'a> HasUartSignal<1> for Alternate<'a, 1, Uart> {}
-impl<'a> HasUartSignal<2> for Alternate<'a, 2, Uart> {}
-impl<'a> HasUartSignal<3> for Alternate<'a, 3, Uart> {}
-impl<'a> HasUartSignal<4> for Alternate<'a, 4, Uart> {}
-impl<'a> HasUartSignal<5> for Alternate<'a, 5, Uart> {}
-impl<'a> HasUartSignal<6> for Alternate<'a, 6, Uart> {}
-impl<'a> HasUartSignal<7> for Alternate<'a, 7, Uart> {}
-impl<'a> HasUartSignal<8> for Alternate<'a, 8, Uart> {}
-impl<'a> HasUartSignal<9> for Alternate<'a, 9, Uart> {}
-impl<'a> HasUartSignal<10> for Alternate<'a, 10, Uart> {}
-impl<'a> HasUartSignal<11> for Alternate<'a, 11, Uart> {}
-impl<'a> HasUartSignal<0> for Alternate<'a, 12, Uart> {}
-impl<'a> HasUartSignal<1> for Alternate<'a, 13, Uart> {}
-impl<'a> HasUartSignal<2> for Alternate<'a, 14, Uart> {}
-impl<'a> HasUartSignal<3> for Alternate<'a, 15, Uart> {}
-impl<'a> HasUartSignal<4> for Alternate<'a, 16, Uart> {}
-impl<'a> HasUartSignal<5> for Alternate<'a, 17, Uart> {}
-impl<'a> HasUartSignal<6> for Alternate<'a, 18, Uart> {}
-impl<'a> HasUartSignal<7> for Alternate<'a, 19, Uart> {}
-impl<'a> HasUartSignal<8> for Alternate<'a, 20, Uart> {}
-impl<'a> HasUartSignal<9> for Alternate<'a, 21, Uart> {}
-impl<'a> HasUartSignal<10> for Alternate<'a, 22, Uart> {}
-impl<'a> HasUartSignal<11> for Alternate<'a, 23, Uart> {}
-impl<'a> HasUartSignal<0> for Alternate<'a, 24, Uart> {}
-impl<'a> HasUartSignal<1> for Alternate<'a, 25, Uart> {}
-impl<'a> HasUartSignal<2> for Alternate<'a, 26, Uart> {}
-impl<'a> HasUartSignal<3> for Alternate<'a, 27, Uart> {}
-impl<'a> HasUartSignal<4> for Alternate<'a, 28, Uart> {}
-impl<'a> HasUartSignal<5> for Alternate<'a, 29, Uart> {}
-impl<'a> HasUartSignal<6> for Alternate<'a, 30, Uart> {}
-impl<'a> HasUartSignal<7> for Alternate<'a, 31, Uart> {}
-impl<'a> HasUartSignal<8> for Alternate<'a, 32, Uart> {}
-impl<'a> HasUartSignal<9> for Alternate<'a, 33, Uart> {}
-impl<'a> HasUartSignal<10> for Alternate<'a, 34, Uart> {}
-impl<'a> HasUartSignal<11> for Alternate<'a, 35, Uart> {}
-impl<'a> HasUartSignal<0> for Alternate<'a, 36, Uart> {}
-impl<'a> HasUartSignal<1> for Alternate<'a, 37, Uart> {}
-impl<'a> HasUartSignal<2> for Alternate<'a, 38, Uart> {}
-impl<'a> HasUartSignal<3> for Alternate<'a, 39, Uart> {}
-impl<'a> HasUartSignal<4> for Alternate<'a, 40, Uart> {}
-impl<'a> HasUartSignal<5> for Alternate<'a, 41, Uart> {}
-impl<'a> HasUartSignal<6> for Alternate<'a, 42, Uart> {}
-impl<'a> HasUartSignal<7> for Alternate<'a, 43, Uart> {}
-impl<'a> HasUartSignal<8> for Alternate<'a, 44, Uart> {}
-impl<'a> HasUartSignal<9> for Alternate<'a, 45, Uart> {}
-
-/// Check if an internal multi-media UART signal is connected to target gpio `Pin`.
-pub trait HasMmUartSignal {}
-
-impl<'a, const N: usize> HasMmUartSignal for Alternate<'a, N, MmUart> {}
-
-/// Valid UART pads.
+/// Pad that can be configured into UART alternate function.
+///
+/// `S` represents the signal identifier for this pad, 0..=11.
 #[diagnostic::on_unimplemented(
-    message = "the I/O pad and signal multiplexer group {Self} is not connected to any UART peripherals on hardware"
+    message = "this GPIO pad has no hardware connection to UART multiplexer signal {S}"
 )]
-pub trait Pads<const U: usize> {
-    /// Checks if this pin configuration includes Request-to-Send feature.
-    const RTS: bool;
-    /// Checks if this pin configuration includes Clear-to-Send feature.
-    const CTS: bool;
-    /// Checks if this pin configuration includes Transmit feature.
-    const TXD: bool;
-    /// Checks if this pin configuration includes Receive feature.
-    const RXD: bool;
-    /// Valid split configuration type for current pads and multiplexers.
-    type Split<'a>;
-
-    fn split<'a>(self, uart: &'a RegisterBlock) -> Self::Split<'a>;
+pub trait IntoUartPad<'a, const S: usize> {
+    /// Configure the GPIO pad into UART state.
+    fn into_uart_pad(self) -> FlexPad<'a>;
 }
 
-#[inline]
-fn from_pads<'a, TX, RX>(
-    uart: &'a RegisterBlock,
-    tx: TX,
-    rx: RX,
-) -> (BlockingTransmitHalf<'a, TX>, BlockingReceiveHalf<'a, RX>) {
-    (
-        BlockingTransmitHalf { uart, _pads: tx },
-        BlockingReceiveHalf { uart, _pads: rx },
-    )
+/// Configure and convert the multiplexer into a UART signal.
+pub trait IntoUartSignal<'a, const S: usize> {
+    /// Converts this multiplexer into transmit state, combine with the pad to build Transmit signal.
+    fn into_transmit<const I: usize>(self, pad: impl IntoUartPad<'a, S>) -> Transmit<'a, I>;
+    /// Converts this multiplexer into receive state, combine with the pad to build Receive signal.
+    fn into_receive<const I: usize>(self, pad: impl IntoUartPad<'a, S>) -> Receive<'a, I>;
+    /// Converts this multiplexer into request-to-send state, combine with the pad to build RequestToSend signal.
+    fn into_request_to_send<const I: usize>(
+        self,
+        pad: impl IntoUartPad<'a, S>,
+    ) -> RequestToSend<'a, I>;
+    /// Converts this multiplexer into clear-to-send state, combine with the pad to build ClearToSend signal.
+    fn into_clear_to_send<const I: usize>(self, pad: impl IntoUartPad<'a, S>)
+    -> ClearToSend<'a, I>;
 }
-
-impl<'a, 'b, const I: usize, const U: usize, const N: usize> Pads<U>
-    for (Alternate<'a, N, Uart>, UartMux<'b, I, MuxTxd<U>>)
-where
-    Alternate<'a, N, Uart>: HasUartSignal<I>,
-{
-    const RTS: bool = false;
-    const CTS: bool = false;
-    const TXD: bool = true;
-    const RXD: bool = false;
-    type Split<'u> = (
-        BlockingTransmitHalf<'u, (Alternate<'a, N, Uart>, UartMux<'b, I, MuxTxd<U>>)>,
-        BlockingReceiveHalf<'u, ()>,
-    );
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        from_pads(uart, self, ())
-    }
-}
-
-impl<
-    'a,
-    'b,
-    'c,
-    'd,
-    const I1: usize,
-    const I2: usize,
-    const U: usize,
-    const N1: usize,
-    const N2: usize,
-> Pads<U>
-    for (
-        (Alternate<'a, N1, Uart>, UartMux<'b, I1, MuxTxd<U>>),
-        (Alternate<'c, N2, Uart>, UartMux<'d, I2, MuxRxd<U>>),
-    )
-where
-    Alternate<'a, N1, Uart>: HasUartSignal<I1>,
-    Alternate<'c, N2, Uart>: HasUartSignal<I2>,
-{
-    const RTS: bool = false;
-    const CTS: bool = false;
-    const TXD: bool = true;
-    const RXD: bool = true;
-    type Split<'u> = (
-        BlockingTransmitHalf<'u, (Alternate<'a, N1, Uart>, UartMux<'b, I1, MuxTxd<U>>)>,
-        BlockingReceiveHalf<'u, (Alternate<'c, N2, Uart>, UartMux<'d, I2, MuxRxd<U>>)>,
-    );
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        from_pads(uart, self.0, self.1)
-    }
-}
-
-impl<
-    'a,
-    'b,
-    'c,
-    'd,
-    const I1: usize,
-    const I2: usize,
-    const U: usize,
-    const N1: usize,
-    const N2: usize,
-> Pads<U>
-    for (
-        (Alternate<'a, N1, Uart>, UartMux<'b, I1, MuxTxd<U>>),
-        (Alternate<'c, N2, Uart>, UartMux<'d, I2, MuxCts<U>>),
-    )
-where
-    Alternate<'a, N1, Uart>: HasUartSignal<I1>,
-    Alternate<'d, N2, Uart>: HasUartSignal<I2>,
-{
-    const RTS: bool = false;
-    const CTS: bool = true;
-    const TXD: bool = true;
-    const RXD: bool = false;
-    type Split<'u> = BlockingTransmitHalf<
-        'u,
-        (
-            (Alternate<'a, N1, Uart>, UartMux<'b, I1, MuxTxd<U>>),
-            (Alternate<'c, N2, Uart>, UartMux<'d, I2, MuxCts<U>>),
-        ),
-    >;
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        BlockingTransmitHalf { uart, _pads: self }
-    }
-}
-
-impl<
-    'a,
-    'b,
-    'c,
-    'd,
-    'e,
-    'f,
-    'g,
-    'h,
-    const I1: usize,
-    const I2: usize,
-    const I3: usize,
-    const I4: usize,
-    const U: usize,
-    const N1: usize,
-    const N2: usize,
-    const N3: usize,
-    const N4: usize,
-> Pads<U>
-    for (
-        (Alternate<'a, N1, Uart>, UartMux<'b, I1, MuxTxd<U>>),
-        (Alternate<'c, N2, Uart>, UartMux<'d, I2, MuxRxd<U>>),
-        (Alternate<'e, N3, Uart>, UartMux<'f, I3, MuxRts<U>>),
-        (Alternate<'g, N4, Uart>, UartMux<'h, I4, MuxCts<U>>),
-    )
-where
-    Alternate<'a, N1, Uart>: HasUartSignal<I1>,
-    Alternate<'c, N2, Uart>: HasUartSignal<I2>,
-    Alternate<'e, N3, Uart>: HasUartSignal<I3>,
-    Alternate<'g, N4, Uart>: HasUartSignal<I4>,
-{
-    const RTS: bool = false;
-    const CTS: bool = true;
-    const TXD: bool = true;
-    const RXD: bool = false;
-    type Split<'u> = (
-        BlockingTransmitHalf<
-            'u,
-            (
-                (Alternate<'a, N1, Uart>, UartMux<'b, I1, MuxTxd<U>>),
-                (Alternate<'g, N4, Uart>, UartMux<'h, I4, MuxCts<U>>),
-            ),
-        >,
-        BlockingReceiveHalf<
-            'u,
-            (
-                (Alternate<'c, N2, Uart>, UartMux<'d, I2, MuxRxd<U>>),
-                (Alternate<'e, N3, Uart>, UartMux<'f, I3, MuxRts<U>>),
-            ),
-        >,
-    );
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        from_pads(uart, (self.0, self.3), (self.1, self.2))
-    }
-}
-
-// TODO: support split for MmUart pads.
 
 const MMUART_UART_ID: usize = 3;
 
-impl<'a, const N: usize> Pads<MMUART_UART_ID> for Alternate<'a, N, MmUart>
-where
-    Alternate<'a, N, MmUart>: HasMmUartSignal,
-{
-    const RTS: bool = { N % 4 == 2 };
-    const CTS: bool = { N % 4 == 3 };
+impl<'a, const N: usize> IntoSignals<'a, MMUART_UART_ID> for Alternate<'a, N, MmUart> {
     const TXD: bool = { N % 4 == 0 };
     const RXD: bool = { N % 4 == 1 };
-    type Split<'u> = ();
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        let _ = uart;
-        ()
-    }
+    const RTS: bool = { N % 4 == 2 };
+    const CTS: bool = { N % 4 == 3 };
 }
 
-impl<'a, 'b, const N1: usize, const N2: usize> Pads<MMUART_UART_ID>
-    for (Alternate<'a, N1, MmUart>, Alternate<'b, N2, MmUart>)
-where
-    Alternate<'a, N1, MmUart>: HasMmUartSignal,
-    Alternate<'b, N2, MmUart>: HasMmUartSignal,
+impl<'a, const N1: usize, const N2: usize> IntoSignals<'a, MMUART_UART_ID>
+    for (Alternate<'a, N1, MmUart>, Alternate<'a, N2, MmUart>)
 {
-    const RTS: bool = { N1 % 4 == 2 || N2 % 4 == 2 };
-    const CTS: bool = { N1 % 4 == 3 || N2 % 4 == 3 };
     const TXD: bool = { N1 % 4 == 0 || N2 % 4 == 0 };
     const RXD: bool = { N1 % 4 == 1 || N2 % 4 == 1 };
-    type Split<'u> = ();
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        let _ = uart;
-        ()
-    }
+    const RTS: bool = { N1 % 4 == 2 || N2 % 4 == 2 };
+    const CTS: bool = { N1 % 4 == 3 || N2 % 4 == 3 };
 }
 
-impl<'a, 'b, 'c, const N1: usize, const N2: usize, const N3: usize> Pads<MMUART_UART_ID>
+impl<'a, const N1: usize, const N2: usize, const N3: usize> IntoSignals<'a, MMUART_UART_ID>
     for (
         Alternate<'a, N1, MmUart>,
-        Alternate<'b, N2, MmUart>,
-        Alternate<'c, N3, MmUart>,
+        Alternate<'a, N2, MmUart>,
+        Alternate<'a, N3, MmUart>,
     )
-where
-    Alternate<'a, N1, MmUart>: HasMmUartSignal,
-    Alternate<'b, N2, MmUart>: HasMmUartSignal,
-    Alternate<'c, N3, MmUart>: HasMmUartSignal,
 {
-    const RTS: bool = { N1 % 4 == 2 || N2 % 4 == 2 || N3 % 4 == 2 };
-    const CTS: bool = { N1 % 4 == 3 || N2 % 4 == 3 || N3 % 4 == 3 };
     const TXD: bool = { N1 % 4 == 0 || N2 % 4 == 0 || N3 % 4 == 0 };
     const RXD: bool = { N1 % 4 == 1 || N2 % 4 == 1 || N3 % 4 == 1 };
-    type Split<'u> = ();
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        let _ = uart;
-        ()
-    }
+    const RTS: bool = { N1 % 4 == 2 || N2 % 4 == 2 || N3 % 4 == 2 };
+    const CTS: bool = { N1 % 4 == 3 || N2 % 4 == 3 || N3 % 4 == 3 };
 }
 
-impl<'a, 'b, 'c, 'd, const N1: usize, const N2: usize, const N3: usize, const N4: usize>
-    Pads<MMUART_UART_ID>
+impl<'a, const N1: usize, const N2: usize, const N3: usize, const N4: usize>
+    IntoSignals<'a, MMUART_UART_ID>
     for (
         Alternate<'a, N1, MmUart>,
-        Alternate<'b, N2, MmUart>,
-        Alternate<'c, N3, MmUart>,
-        Alternate<'d, N4, MmUart>,
+        Alternate<'a, N2, MmUart>,
+        Alternate<'a, N3, MmUart>,
+        Alternate<'a, N4, MmUart>,
     )
-where
-    Alternate<'a, N1, MmUart>: HasMmUartSignal,
-    Alternate<'b, N2, MmUart>: HasMmUartSignal,
-    Alternate<'c, N3, MmUart>: HasMmUartSignal,
-    Alternate<'d, N4, MmUart>: HasMmUartSignal,
 {
-    const RTS: bool = { N1 % 4 == 2 || N2 % 4 == 2 || N3 % 4 == 2 || N4 % 4 == 2 };
-    const CTS: bool = { N1 % 4 == 3 || N2 % 4 == 3 || N3 % 4 == 3 || N4 % 4 == 3 };
     const TXD: bool = { N1 % 4 == 0 || N2 % 4 == 0 || N3 % 4 == 0 || N4 % 4 == 0 };
     const RXD: bool = { N1 % 4 == 1 || N2 % 4 == 1 || N3 % 4 == 1 || N4 % 4 == 1 };
-    type Split<'u> = ();
-    #[inline]
-    fn split<'u>(self, uart: &'u RegisterBlock) -> Self::Split<'u> {
-        let _ = uart;
-        ()
-    }
+    const RTS: bool = { N1 % 4 == 2 || N2 % 4 == 2 || N3 % 4 == 2 || N4 % 4 == 2 };
+    const CTS: bool = { N1 % 4 == 3 || N2 % 4 == 3 || N3 % 4 == 3 || N4 % 4 == 3 };
 }

--- a/bouffalo-hal/src/uart/signal.rs
+++ b/bouffalo-hal/src/uart/signal.rs
@@ -1,0 +1,122 @@
+use crate::glb::v2::RegisterBlock;
+use crate::gpio::FlexPad;
+use core::marker::PhantomData;
+
+/// Transmit signal, combined from a GPIO pad and a UART multiplexer.
+pub struct Transmit<'a, const I: usize> {
+    _mux_base: PhantomData<&'a RegisterBlock>,
+    _pad: PhantomData<FlexPad<'a>>,
+}
+
+impl<'a, const I: usize> Transmit<'a, I> {
+    #[doc(hidden)]
+    #[inline]
+    pub const fn __new(mux_base: &'a RegisterBlock, pad: FlexPad<'a>) -> Self {
+        let _ = (mux_base, pad);
+        Transmit {
+            _mux_base: PhantomData,
+            _pad: PhantomData,
+        }
+    }
+}
+
+/// Receive signal, combined from a GPIO pad and a UART multiplexer.
+pub struct Receive<'a, const I: usize> {
+    _mux_base: PhantomData<&'a RegisterBlock>,
+    _pad: PhantomData<FlexPad<'a>>,
+}
+
+impl<'a, const I: usize> Receive<'a, I> {
+    #[doc(hidden)]
+    #[inline]
+    pub const fn __new(mux_base: &'a RegisterBlock, pad: FlexPad<'a>) -> Self {
+        let _ = (mux_base, pad);
+        Receive {
+            _mux_base: PhantomData,
+            _pad: PhantomData,
+        }
+    }
+}
+
+/// Request-To-Send (RTS) signal, combined from a GPIO pad and a UART multiplexer.
+pub struct RequestToSend<'a, const I: usize> {
+    _mux_base: PhantomData<&'a RegisterBlock>,
+    _pad: PhantomData<FlexPad<'a>>,
+}
+
+impl<'a, const I: usize> RequestToSend<'a, I> {
+    #[doc(hidden)]
+    #[inline]
+    pub const fn __new(mux_base: &'a RegisterBlock, pad: FlexPad<'a>) -> Self {
+        let _ = (mux_base, pad);
+        RequestToSend {
+            _mux_base: PhantomData,
+            _pad: PhantomData,
+        }
+    }
+}
+
+/// Clear-To-Send (CTS) signal, combined from a GPIO pad and a UART multiplexer.
+pub struct ClearToSend<'a, const I: usize> {
+    _mux_base: PhantomData<&'a RegisterBlock>,
+    _pad: PhantomData<FlexPad<'a>>,
+}
+
+impl<'a, const I: usize> ClearToSend<'a, I> {
+    #[doc(hidden)]
+    #[inline]
+    pub const fn __new(mux_base: &'a RegisterBlock, pad: FlexPad<'a>) -> Self {
+        let _ = (mux_base, pad);
+        ClearToSend {
+            _mux_base: PhantomData,
+            _pad: PhantomData,
+        }
+    }
+}
+
+/// Signals that can be converted into valid UART signals.
+pub trait IntoSignals<'a, const I: usize> {
+    /// Checks if this configuration includes Request-to-Send feature.
+    const RTS: bool;
+    /// Checks if this configuration includes Clear-to-Send feature.
+    const CTS: bool;
+    /// Checks if this configuration includes Transmit feature.
+    const TXD: bool;
+    /// Checks if this configuration includes Receive feature.
+    const RXD: bool;
+}
+
+impl<'a, const I: usize> IntoSignals<'a, I> for Transmit<'a, I> {
+    const TXD: bool = true;
+    const RXD: bool = false;
+    const RTS: bool = false;
+    const CTS: bool = false;
+}
+
+impl<'a, const I: usize> IntoSignals<'a, I> for Receive<'a, I> {
+    const TXD: bool = false;
+    const RXD: bool = true;
+    const RTS: bool = false;
+    const CTS: bool = false;
+}
+
+impl<'a, const I: usize> IntoSignals<'a, I> for (Transmit<'a, I>, Receive<'a, I>) {
+    const TXD: bool = true;
+    const RXD: bool = true;
+    const RTS: bool = false;
+    const CTS: bool = false;
+}
+
+impl<'a, const I: usize> IntoSignals<'a, I>
+    for (
+        Transmit<'a, I>,
+        Receive<'a, I>,
+        RequestToSend<'a, I>,
+        ClearToSend<'a, I>,
+    )
+{
+    const TXD: bool = true;
+    const RXD: bool = true;
+    const RTS: bool = true;
+    const CTS: bool = true;
+}

--- a/examples/multicore/multicore-demo/dsp/src/main.rs
+++ b/examples/multicore/multicore-demo/dsp/src/main.rs
@@ -8,14 +8,10 @@ use panic_halt as _;
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
 
     loop {
         writeln!(

--- a/examples/peripherals/i2c-demo/src/main.rs
+++ b/examples/peripherals/i2c-demo/src/main.rs
@@ -11,14 +11,10 @@ const SCREEN_ADDRESS: u8 = 0x15;
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
     let mut led = p.gpio.io8.into_floating_output();
 
     let scl = p.gpio.io6;

--- a/examples/peripherals/lz4d-demo/src/main.rs
+++ b/examples/peripherals/lz4d-demo/src/main.rs
@@ -12,14 +12,10 @@ static mut LZ4_OUTPUT: [u8; 2048] = [0u8; 2048];
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
 
     unsafe { p.glb.clock_config_1.modify(|v| v.enable_lz4d()) };
 

--- a/examples/peripherals/psram-demo/src/main.rs
+++ b/examples/peripherals/psram-demo/src/main.rs
@@ -16,14 +16,10 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     led.set_state(led_state).ok();
 
     // init serial
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
 
     writeln!(serial, "Welcome to psram-demo🦀!").ok();
 

--- a/examples/peripherals/sdcard-demo/src/main.rs
+++ b/examples/peripherals/sdcard-demo/src/main.rs
@@ -19,14 +19,10 @@ impl embedded_sdmmc::TimeSource for MyTimeSource {
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
     writeln!(serial, "Hello world!").ok();
 
     let mut led = p.gpio.io8.into_floating_output();

--- a/examples/peripherals/sdcard-gpt-demo/src/main.rs
+++ b/examples/peripherals/sdcard-gpt-demo/src/main.rs
@@ -189,14 +189,10 @@ impl<T: embedded_sdmmc::BlockDevice> fatfs::Seek for MyVolume<T> {
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
     writeln!(serial, "Hello world!").ok();
 
     let mut led = p.gpio.io8.into_floating_output();

--- a/examples/peripherals/sdh-demo/src/main.rs
+++ b/examples/peripherals/sdh-demo/src/main.rs
@@ -28,14 +28,10 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     led.set_state(led_state).ok();
 
     // Init serial.
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = UartConfig::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
 
     writeln!(serial, "Welcome to sdh-demo!").ok();
 

--- a/examples/peripherals/sdh-dma-demo/src/main.rs
+++ b/examples/peripherals/sdh-dma-demo/src/main.rs
@@ -29,14 +29,10 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     led.set_state(led_state).ok();
 
     // Init serial.
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = UartConfig::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
 
     writeln!(serial, "Welcome to sdh-dma-demo!").ok();
 

--- a/examples/peripherals/uart-async-demo/src/main.rs
+++ b/examples/peripherals/uart-async-demo/src/main.rs
@@ -12,7 +12,7 @@ use bouffalo_rt::{
 use embedded_time::rate::*;
 use panic_halt as _;
 
-async fn async_main(p: Peripherals<'_>, c: Clocks) {
+async fn async_main(p: Peripherals, c: Clocks) {
     // enable jtag
     p.gpio.io0.into_jtag_d0();
     p.gpio.io1.into_jtag_d0();

--- a/examples/peripherals/uart-cli-demo/src/main.rs
+++ b/examples/peripherals/uart-cli-demo/src/main.rs
@@ -30,14 +30,10 @@ enum LedCommand {
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
 
     let (mut tx, mut rx) = serial.split();
 

--- a/examples/peripherals/uart-demo/src/main.rs
+++ b/examples/peripherals/uart-demo/src/main.rs
@@ -8,14 +8,10 @@ use panic_halt as _;
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
-
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
     let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
 
     let mut led = p.gpio.io8.into_floating_output();
     let mut led_state = PinState::Low;

--- a/examples/peripherals/uart-dma-demo/src/main.rs
+++ b/examples/peripherals/uart-dma-demo/src/main.rs
@@ -8,15 +8,13 @@ use panic_halt as _;
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
-    let tx = p.gpio.io14.into_uart();
-    let rx = p.gpio.io15.into_uart();
-    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
-    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
-    let pads = ((tx, sig2), (rx, sig3));
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
+    let config = Config::default().set_baudrate(2000000.Bd());
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
+
     let mut led = p.gpio.io8.into_floating_output();
 
-    let config = Config::default().set_baudrate(2000000.Bd());
-    let mut serial = p.uart0.freerun(config, pads, &c).unwrap().enable_tx_dma();
     let tx_config = DmaChannelConfig {
         direction: DmaMode::Mem2Periph,
         src_req: None,


### PR DESCRIPTION
This pull reqeust rearranges UART signal multiplexers and I/O pad constraints.

Before:

```rust
    let tx = p.gpio.io14.into_uart();
    let rx = p.gpio.io15.into_uart();
    let sig2 = p.uart_muxes.sig2.into_transmit::<0>();
    let sig3 = p.uart_muxes.sig3.into_receive::<0>();
    let pads = ((tx, sig2), (rx, sig3));

    let config = Config::default().set_baudrate(2000000.Bd());
    let mut serial = p.uart0.freerun(config, pads, &c).unwrap();
```

After:

```rust
    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
    let config = Config::default().set_baudrate(2000000.Bd());
    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
```