### PR TITLE
feat(all): add chip interrupt support and blri new features

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [alias]
 blri = "run --package blri --release --"
+blri-default = "run --package blri --release -- default"
 
 [target.'cfg(target_os = "none")']
 runner = "cargo blri run"

--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -45,7 +45,7 @@ jobs:
         # TOOLCHAIN: [stable] # TODO
         TOOLCHAIN: [nightly]
         EXAMPLES: [gpio-demo, i2c-demo, i2c-screen-demo, jtag-demo, lz4d-demo, psram-demo, pwm-demo, 
-          sdcard-demo, sdcard-gpt-demo, sdh-demo, sdh-dma-demo, spi-demo, uart-demo, uart-async-demo, uart-cli-demo]
+          sdcard-demo, sdcard-gpt-demo, sdh-demo, sdh-dma-demo, spi-demo, uart-demo, uart-async-demo, uart-cli-demo, adc-dma-demo]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -70,7 +70,7 @@ jobs:
       matrix:
         TARGET: [riscv32imac-unknown-none-elf]
         TOOLCHAIN: [nightly]
-        EXAMPLES: [uart-bl616-demo, uart-dma-demo, adc-tsen-demo, adc-poll-demo, adc-poll-diff-demo, adc-poll-onechan-demo, adc-vbat-demo]
+        EXAMPLES: [uart-bl616-demo, uart-dma-demo, adc-tsen-demo, adc-poll-demo, adc-poll-diff-demo, adc-poll-onechan-demo, adc-vbat-demo, adc-async-demo]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ members = [
     "examples/peripherals/psram-demo",
     "examples/peripherals/sdh-demo",
     "examples/peripherals/sdh-dma-demo",
+    "examples/peripherals/adc-dma-demo",
+    "examples/peripherals/adc-async-demo",
     "examples/peripherals/adc-tsen-demo",
     "examples/peripherals/adc-poll-demo",
     "examples/peripherals/adc-poll-diff-demo",

--- a/blri/Cargo.toml
+++ b/blri/Cargo.toml
@@ -16,6 +16,12 @@ serialport = { version = "4.3", default-features = false }
 object = "0.36.7"
 same-file = "1.0.6"
 bouffalo-rt = { path = "../bouffalo-rt", features = ["image_fuse"] }
+ctrlc = "3.4"
+crossterm = "0.27"
+colored = "2.1"
+toml = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+home = "0.5"
 
 [dev-dependencies]
 tempfile = "3.12.0"

--- a/blri/README.md
+++ b/blri/README.md
@@ -1,37 +1,123 @@
 # blri
 
-#### 介绍
-博流物联网芯片ROM镜像补全和烧录工具
+A command-line tool for Bouffalo Lab IoT chips that handles ROM image completion, patching, and flashing with integrated serial console support.
 
-#### 软件架构
-软件架构说明
+## Features
 
+- **ELF to Binary Conversion**: Convert ELF files to binary format suitable for flashing
+- **Image Patching**: Automatically fix CRC32 checksums and apply necessary corrections
+- **Device Flashing**: Flash binary images to Bouffalo Lab chips via ISP (In-System Programming)
+- **Serial Console**: Built-in serial console/monitor for debugging after flashing
+- **Configuration Management**: Save and reuse flashing configurations for different projects
+- **Smart Port Detection**: Automatically detect available serial ports
 
-#### 安装教程
+## Usage
 
-1.  xxxx
-2.  xxxx
-3.  xxxx
+### Basic Commands
 
-#### 使用说明
+```bash
+# Convert ELF to binary and patch
+blri elf2bin input.elf -o output.bin --patch
 
-1.  xxxx
-2.  xxxx
-3.  xxxx
+# Flash image to device
+blri flash image.bin --port /dev/ttyUSB0 --reset
 
-#### 参与贡献
+# One-step: convert, patch, flash, and open uart in console mode
+blri run target/riscv64imac-unknown-none-elf/release/my-app --reset --console
 
-1.  Fork 本仓库
-2.  新建 Feat_xxx 分支
-3.  提交代码
-4.  新建 Pull Request
+# Use saved configuration for quick development
+blri default
+```
 
+### Configuration Management
 
-#### 特技
+blri automatically saves successful configurations including:
+- Target architecture
+- Build mode (debug/release)
+- Package name
+- Serial port and baudrate
+- Reset and console preferences
 
-1.  使用 Readme\_XXX.md 来支持不同的语言，例如 Readme\_en.md, Readme\_zh.md
-2.  Gitee 官方博客 [blog.gitee.com](https://blog.gitee.com)
-3.  你可以 [https://gitee.com/explore](https://gitee.com/explore) 这个地址来了解 Gitee 上的优秀开源项目
-4.  [GVP](https://gitee.com/gvp) 全称是 Gitee 最有价值开源项目，是综合评定出的优秀开源项目
-5.  Gitee 官方提供的使用手册 [https://gitee.com/help](https://gitee.com/help)
-6.  Gitee 封面人物是一档用来展示 Gitee 会员风采的栏目 [https://gitee.com/gitee-stars/](https://gitee.com/gitee-stars/)
+When conflicts are detected, blri will prompt:
+1. **First confirmation**: "Use current configuration instead of saved configuration?"
+2. **Second confirmation**: "Save current configuration for future use?"
+
+### Serial Console
+
+After flashing, you can open a serial console to interact with your device:
+
+```bash
+# Open console mode (interactive)
+blri run my-app --console
+
+# Open monitor mode (read-only)
+blri run my-app
+```
+
+Console features:
+- Real-time device output display
+- Interactive command input (console mode)
+- Configurable baudrate (default: 2000000 bps)
+- Exit with Ctrl+C
+
+### Integration with Cargo
+
+Add to your `.cargo/config.toml`:
+
+```toml
+[alias]
+blri = "run --package blri --release --"
+blri-default = "run --package blri --release -- default"
+```
+
+Then use:
+
+```bash
+# From project root
+cargo blri run target/riscv64imac-unknown-none-elf/release/my-app --reset --console
+
+# Quick run with saved config
+cargo blri-default
+```
+
+## Examples
+
+### Development Workflow
+
+```bash
+# First time setup
+cargo build --target riscv64imac-unknown-none-elf --release -p my-project
+cargo blri run target/riscv64imac-unknown-none-elf/release/my-project --reset --console
+
+# Subsequent runs
+cargo build --target riscv64imac-unknown-none-elf --release -p my-project
+cargo blri-default
+```
+
+### Flashing Different Projects
+
+```bash
+# Switch to a different project
+cargo blri run target/riscv64imac-unknown-none-elf/release/uart-demo --reset
+
+# blri will detect configuration differences and prompt for confirmation
+```
+
+## Configuration File
+
+Configurations are automatically saved to `target/settings.toml`:
+
+```toml
+target = "riscv64imac-unknown-none-elf"
+release = true
+package = "my-project"
+binary_path = "target/riscv64imac-unknown-none-elf/release/my-project"
+port = "/dev/ttyUSB0"
+baudrate = 2000000
+reset = true
+console = true
+```
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE files for details.

--- a/blri/src/lib.rs
+++ b/blri/src/lib.rs
@@ -1,4 +1,5 @@
 mod isp;
+pub mod settings;
 use bouffalo_rt::soc::bl808::HalBootheader;
 use bouffalo_rt::{BFLB_BOOT2_HEADER_MAGIC, BasicConfigFlags};
 use clap::Args;

--- a/blri/src/main.rs
+++ b/blri/src/main.rs
@@ -1,14 +1,23 @@
 use blri::{
     BootInfo, DeviceReset, EraseFlash, Error, GetBootInfo, ImageToFuse, IspCommand, IspError,
-    WriteFlash, elf_to_bin,
+    WriteFlash, elf_to_bin, settings::BlriConfig,
 };
 use clap::{Args, Parser, Subcommand};
+use colored::*;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    terminal::{disable_raw_mode, enable_raw_mode},
+};
 use inquire::Select;
 use std::{
     fs::{self, File},
-    io::{Read, Write},
+    io::{Read, Write, stdin, stdout},
     path::{Path, PathBuf},
-    thread::sleep,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, sleep},
     time::Duration,
 };
 
@@ -28,8 +37,10 @@ enum Commands {
     Flash(Flash),
     /// Convert ELF file to binary file.
     Elf2bin(Elf2Bin),
-    /// Convert ELF to binary file, patch and flash image.
+    /// Convert ELF to binary file, patch, flash image and open serial.
     Run(Run),
+    /// Use saved configuration to run the default project.
+    Default(DefaultRun),
 }
 
 #[derive(Args)]
@@ -65,13 +76,26 @@ struct Elf2Bin {
 
 #[derive(Args)]
 struct Run {
-    /// The path to the input ELF file.
-    input_file: PathBuf,
+    /// The path to the input ELF file. If not provided, will use the saved configuration.
+    input_file: Option<PathBuf>,
     /// The serial port to use for flashing. If not provided, a list of available ports will be shown.
     #[arg(short, long)]
     port: Option<String>,
     #[arg(long, default_value_t = false)]
     reset: bool,
+    /// Open serial console after flashing is complete
+    #[arg(long, default_value_t = false)]
+    console: bool,
+}
+
+#[derive(Args)]
+struct DefaultRun {
+    /// Override reset setting
+    #[arg(long)]
+    reset: Option<bool>,
+    /// Override console setting
+    #[arg(long)]
+    console: Option<bool>,
 }
 
 #[derive(Args)]
@@ -90,6 +114,10 @@ struct Fuse {
 
 fn main() {
     let args = Cli::parse();
+
+    // Load existing configuration
+    let mut config = BlriConfig::load();
+
     match args.command {
         Commands::Patch(patch) => {
             let input_path = &patch.input;
@@ -97,8 +125,10 @@ fn main() {
             patch_image(input_path, output_path);
         }
         Commands::Flash(flash) => {
-            let port = use_or_select_flash_port(&flash.port);
-            flash_image(&flash.image, &port, flash.reset);
+            let (port, baudrate) = use_or_select_flash_port_and_baudrate(&flash.port, None);
+            if let Err(e) = flash_image(&flash.image, &port, flash.reset, baudrate) {
+                println!("error: {}", e);
+            }
         }
         Commands::Elf2bin(elf2bin) => {
             let input_path = elf2bin.input;
@@ -114,12 +144,10 @@ fn main() {
             }
         }
         Commands::Run(run) => {
-            let port = use_or_select_flash_port(&run.port);
-            let elf_file = run.input_file;
-            let bin_file = elf_file.with_extension("bin");
-            elf_to_bin(&elf_file, &bin_file).expect("convert ELF to BIN");
-            patch_image(&bin_file, &bin_file);
-            flash_image(&bin_file, &port, run.reset);
+            handle_run_command(run, &mut config);
+        }
+        Commands::Default(default_run) => {
+            handle_default_command(default_run, &mut config);
         }
     }
 }
@@ -196,8 +224,11 @@ fn print_patch_error(e: Error) {
     }
 }
 
-fn use_or_select_flash_port(port_parameter: &Option<String>) -> String {
-    match port_parameter {
+fn use_or_select_flash_port_and_baudrate(
+    port_parameter: &Option<String>,
+    baudrate_parameter: Option<u32>,
+) -> (String, u32) {
+    let port = match port_parameter {
         Some(port) => port.clone(),
         None => {
             let ports = serialport::available_ports().expect("list serial ports");
@@ -207,50 +238,148 @@ fn use_or_select_flash_port(port_parameter: &Option<String>) -> String {
                 .prompt()
                 .expect("select serial port")
         }
+    };
+
+    let baudrate = match baudrate_parameter {
+        Some(rate) => rate,
+        None => select_baudrate(),
+    };
+
+    (port, baudrate)
+}
+
+fn select_baudrate() -> u32 {
+    // Common baudrates from high to low, with 2000000 as default
+    let baudrate_options = vec![
+        "2000000 (default)".to_string(),
+        "1500000".to_string(),
+        "1000000".to_string(),
+        "921600".to_string(),
+        "460800".to_string(),
+        "230400".to_string(),
+        "115200".to_string(),
+        "57600".to_string(),
+        "38400".to_string(),
+        "19200".to_string(),
+        "9600".to_string(),
+        "Custom".to_string(),
+    ];
+
+    let selection = Select::new("Select baudrate", baudrate_options)
+        .with_starting_cursor(0) // Default to 2000000
+        .prompt()
+        .expect("select baudrate");
+
+    match selection.as_str() {
+        "2000000 (default)" => 2000000,
+        "1500000" => 1500000,
+        "1000000" => 1000000,
+        "921600" => 921600,
+        "460800" => 460800,
+        "230400" => 230400,
+        "115200" => 115200,
+        "57600" => 57600,
+        "38400" => 38400,
+        "19200" => 19200,
+        "9600" => 9600,
+        "Custom" => {
+            use inquire::Text;
+            let input = Text::new("Enter custom baudrate:")
+                .prompt()
+                .expect("get custom baudrate input");
+
+            match input.trim().parse::<u32>() {
+                Ok(rate) if rate > 0 => rate,
+                Ok(_) => {
+                    eprintln!("Error: Baudrate must be a positive integer");
+                    std::process::exit(1);
+                }
+                Err(_) => {
+                    eprintln!(
+                        "Error: Invalid baudrate '{}'. Must be a positive integer",
+                        input.trim()
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+        _ => unreachable!(),
     }
 }
 
-fn flash_image(image: impl AsRef<Path>, port: &str, device_reset: bool) {
-    const BAUDRATE: u32 = 2000000;
+#[allow(dead_code)]
+fn use_or_select_flash_port(port_parameter: &Option<String>) -> String {
+    let (port, _) = use_or_select_flash_port_and_baudrate(port_parameter, Some(2000000));
+    port
+}
 
-    let image_data = fs::read(image).expect("read image file");
+fn flash_image(
+    image: impl AsRef<Path>,
+    port: &str,
+    device_reset: bool,
+    baudrate: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let image_data = fs::read(image)?;
     if image_data.len() > u16::MAX as usize {
-        println!("error: image too large.");
-        return;
+        return Err("Image too large".into());
     }
 
-    let serial = serialport::new(port, BAUDRATE)
+    println!("Connecting to device on {} at {} bps...", port, baudrate);
+    println!("Please ensure your device is in download mode:");
+    println!("1. Hold BOOT button and press RESET button");
+    println!("2. Release RESET button, then release BOOT button");
+    println!("3. The device should now be in ISP mode");
+
+    let serial = serialport::new(port, baudrate)
         .timeout(std::time::Duration::from_secs(1))
         .open()
-        .expect("open serial port");
+        .map_err(|e| format!("Failed to open serial port {}: {}", port, e))?;
 
     let mut isp = UartIsp::new(serial);
 
-    let boot_info = isp.get_boot_info().expect("get boot info");
+    let boot_info = isp.get_boot_info().map_err(|e| {
+        format!("Failed to get boot info: {:?}\nPlease check:\n1. Device is connected and powered on\n2. Device is in ISP/download mode (BOOT button sequence)\n3. Correct serial port is selected\n4. No other programs are using the serial port", e)
+    })?;
+
     print_boot_info(&boot_info);
 
     isp.set_flash_pin(boot_info.flash_pin())
-        .expect("set flash pin");
+        .map_err(|e| format!("Failed to set flash pin: {:?}", e))?;
 
-    let flash_id = isp.read_flash_id().expect("read flash id");
+    let flash_id = isp
+        .read_flash_id()
+        .map_err(|e| format!("Failed to read flash id: {:?}", e))?;
     println!("flash id: {:x?}", flash_id);
 
-    let flash_config = get_flash_config_for_flash_id(flash_id).expect("retrieve config for flash");
+    let flash_config = get_flash_config_for_flash_id(flash_id).ok_or_else(|| {
+        format!(
+            "Unsupported flash id {:x?}. Supported: W25Q128 (EF4018)",
+            flash_id
+        )
+    })?;
 
     isp.set_flash_config(flash_config)
-        .expect("set flash config");
+        .map_err(|e| format!("Failed to set flash config: {:?}", e))?;
 
+    println!("Erasing flash...");
     isp.erase_flash(0, image_data.len() as u32)
-        .expect("erase flash");
+        .map_err(|e| format!("Failed to erase flash: {:?}", e))?;
 
-    isp.write_flash(&image_data).expect("write image");
+    println!("Writing image...");
+    isp.write_flash(&image_data)
+        .map_err(|e| format!("Failed to write image: {:?}", e))?;
 
     println!("flashing done.");
 
     if device_reset {
-        isp.device_reset().expect("reset device");
-        println!("resetting device...")
+        if let Err(e) = isp.device_reset() {
+            println!("warning: failed to reset device: {:?}", e);
+        } else {
+            println!("resetting device...");
+        }
     }
+
+    Ok(())
 }
 
 fn print_boot_info(boot_info: &BootInfo) {
@@ -430,4 +559,708 @@ fn query_response(mut serial: impl Read, response_payload: bool) -> Result<u16, 
         return Ok(u16::from_le_bytes(len_buf));
     }
     Ok(0)
+}
+
+fn open_serial_console(port: &str, is_console_mode: bool, baudrate: u32) {
+    // Wait for device to start and collect initial output
+    println!("Waiting for device to start...");
+    thread::sleep(Duration::from_millis(1500));
+
+    let mut serial = match serialport::new(port, baudrate)
+        .timeout(Duration::from_millis(100))
+        .open()
+    {
+        Ok(port) => port,
+        Err(e) => {
+            println!("Failed to open serial port for console: {}", e);
+            return;
+        }
+    };
+
+    thread::sleep(Duration::from_millis(500));
+
+    // Collect all buffered data before showing banner
+    let mut all_buffered_data = String::new();
+    let mut buffer = [0u8; 2048];
+
+    for i in 0..10 {
+        match serial.read(&mut buffer) {
+            Ok(bytes_read) if bytes_read > 0 => {
+                let data = String::from_utf8_lossy(&buffer[..bytes_read]);
+                all_buffered_data.push_str(&data);
+                if i < 3 {
+                    thread::sleep(Duration::from_millis(100));
+                } else {
+                    thread::sleep(Duration::from_millis(200));
+                }
+            }
+            _ => {
+                thread::sleep(Duration::from_millis(100));
+                if i > 5 && all_buffered_data.is_empty() {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Show formatted console start message
+    show_console_banner(port, baudrate, is_console_mode);
+
+    // Display collected buffered data
+    if !all_buffered_data.trim().is_empty() {
+        let mut remaining_data = all_buffered_data.as_str();
+
+        while !remaining_data.is_empty() {
+            if let Some(newline_pos) = remaining_data.find('\n') {
+                let line = &remaining_data[..newline_pos];
+                if !line.trim().is_empty() {
+                    let formatted_line = format_serial_output(line.trim_end_matches('\r'));
+                    println!("{}", formatted_line);
+                }
+                remaining_data = &remaining_data[newline_pos + 1..];
+            } else {
+                if !remaining_data.trim().is_empty() {
+                    let formatted_partial =
+                        format_serial_output(remaining_data.trim_end_matches('\r'));
+                    print!("{}", formatted_partial);
+                    let _ = stdout().flush();
+                }
+                break;
+            }
+        }
+    }
+
+    // Use monitor mode for non-interactive display
+    if !is_console_mode {
+        open_serial_monitor_only(port, serial);
+        return;
+    }
+
+    // Enable console mode with raw input
+    if let Err(e) = enable_raw_mode() {
+        println!("Warning: failed to enable raw mode: {}", e);
+        println!("Falling back to line-buffered input...");
+        open_serial_console_fallback(port, &mut serial, is_console_mode);
+        return;
+    }
+
+    let running = Arc::new(AtomicBool::new(true));
+
+    let mut serial_clone = match serial.try_clone() {
+        Ok(s) => s,
+        Err(e) => {
+            println!("Failed to clone serial port: {}", e);
+            let _ = disable_raw_mode();
+            return;
+        }
+    };
+    let running_clone = running.clone();
+
+    // Handle serial port reading in separate thread
+    let read_handle = thread::spawn(move || {
+        let mut buffer = [0u8; 1024];
+        let mut line_buffer = String::new();
+
+        while running_clone.load(Ordering::SeqCst) {
+            match serial_clone.read(&mut buffer) {
+                Ok(bytes_read) if bytes_read > 0 => {
+                    let data = &buffer[..bytes_read];
+                    let output = String::from_utf8_lossy(data);
+
+                    for ch in output.chars() {
+                        match ch {
+                            '\n' => {
+                                let formatted_line = format_serial_output(&line_buffer);
+                                print!("{}\r\n", formatted_line);
+                                line_buffer.clear();
+                            }
+                            '\r' => {
+                                let formatted_line = format_serial_output(&line_buffer);
+                                print!("{}\r", formatted_line);
+                                line_buffer.clear();
+                            }
+                            '\t' => {
+                                line_buffer.push('\t');
+                            }
+                            c if c.is_control() && c != '\x08' => {
+                                continue;
+                            }
+                            c => {
+                                line_buffer.push(c);
+                            }
+                        }
+                    }
+
+                    if !line_buffer.is_empty() && !output.ends_with('\n') && !output.ends_with('\r')
+                    {
+                        let formatted_partial = format_serial_output(&line_buffer);
+                        print!("{}", formatted_partial);
+                        line_buffer.clear();
+                    }
+
+                    let _ = stdout().flush();
+                }
+                Ok(_) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+                    // Timeout is expected, continue
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("Error reading from serial port: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+
+    // Handle keyboard input and send to device
+    while running.load(Ordering::SeqCst) {
+        if event::poll(Duration::from_millis(100)).unwrap_or(false) {
+            match event::read() {
+                Ok(Event::Key(key_event)) => {
+                    if key_event.modifiers.contains(KeyModifiers::CONTROL)
+                        && key_event.code == KeyCode::Char('c')
+                    {
+                        running.store(false, Ordering::SeqCst);
+                        break;
+                    }
+
+                    let bytes_to_send = match key_event.code {
+                        KeyCode::Char(c) => vec![c as u8],
+                        KeyCode::Enter => vec![b'\r'],
+                        KeyCode::Backspace => vec![0x08],
+                        KeyCode::Tab => vec![b'\t'],
+                        KeyCode::Esc => vec![0x1b],
+                        KeyCode::Up | KeyCode::Down | KeyCode::Left | KeyCode::Right => continue,
+                        KeyCode::Home | KeyCode::End | KeyCode::PageUp | KeyCode::PageDown => {
+                            continue;
+                        }
+                        KeyCode::Insert | KeyCode::Delete => continue,
+                        KeyCode::F(_) => continue,
+                        _ => continue,
+                    };
+
+                    if let Err(e) = serial.write_all(&bytes_to_send) {
+                        eprintln!("Error writing to serial port: {}", e);
+                        break;
+                    }
+                    let _ = serial.flush();
+                }
+                Ok(_) => {
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("Error reading input: {}", e);
+                    break;
+                }
+            }
+        }
+    }
+
+    running.store(false, Ordering::SeqCst);
+    let _ = disable_raw_mode();
+    let _ = read_handle.join();
+
+    println!("\n{}", "Serial console closed.".bright_green());
+}
+
+fn show_console_banner(port: &str, baudrate: u32, is_console_mode: bool) {
+    const SEPARATOR_WIDTH: usize = 50; // Fixed width for consistency
+
+    let separator = "─".repeat(SEPARATOR_WIDTH);
+
+    println!();
+    println!("{}", separator.bright_cyan());
+
+    if is_console_mode {
+        println!("  🖥️  {}", "Serial Console".bright_white().bold());
+    } else {
+        println!("  📡 {}", "Serial Monitor".bright_white().bold());
+    }
+
+    println!("{}", separator.bright_cyan());
+    println!(
+        "  ⚡ {}: {}",
+        "Speed".bright_yellow(),
+        format!("{} bps", baudrate).bright_white()
+    );
+    println!("  🔌 {}: {}", "Port".bright_yellow(), port.bright_white());
+    println!("  ✅ {}", "Ready".bright_green().bold());
+    println!("  🚪 Press {} to exit", "Ctrl+C".bright_red().bold());
+    println!("{}", separator.bright_cyan());
+    println!();
+
+    if is_console_mode {
+        println!("📡 {}", "Console Output:".bright_magenta().bold());
+    } else {
+        println!("📡 {}", "Device Output:".bright_magenta().bold());
+    }
+    println!();
+}
+
+fn format_serial_output(text: &str) -> String {
+    if text.trim().is_empty() {
+        return text.to_string();
+    }
+
+    if text.starts_with('>') {
+        text.bright_green().bold().to_string()
+    } else if text.contains("error") || text.contains("Error") || text.contains("ERROR") {
+        text.bright_red().to_string()
+    } else if text.contains("warning") || text.contains("Warning") || text.contains("WARN") {
+        text.bright_yellow().to_string()
+    } else if text.contains("Command") || text.contains("help") {
+        text.bright_cyan().to_string()
+    } else if text.contains("Unknown command") {
+        text.bright_red().to_string()
+    } else if text.contains(':')
+        && (text.contains("on") || text.contains("off") || text.contains("switch"))
+    {
+        text.bright_blue().to_string()
+    } else {
+        text.white().to_string()
+    }
+}
+
+fn open_serial_console_fallback(
+    _port: &str,
+    serial: &mut Box<dyn serialport::SerialPort>,
+    _is_console_mode: bool,
+) {
+    println!(
+        "{}",
+        "Using line-buffered input mode. Press Ctrl+C to exit.".bright_yellow()
+    );
+
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+        println!("\n{}", "Exiting serial console...".bright_green());
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let mut serial_clone = serial.try_clone().expect("Failed to clone serial port");
+    let running_clone = running.clone();
+
+    let read_handle = thread::spawn(move || {
+        let mut buffer = [0u8; 1024];
+        while running_clone.load(Ordering::SeqCst) {
+            match serial_clone.read(&mut buffer) {
+                Ok(bytes_read) if bytes_read > 0 => {
+                    let data = &buffer[..bytes_read];
+                    let output = String::from_utf8_lossy(data);
+
+                    // Apply highlighting to each line
+                    for line in output.lines() {
+                        let formatted_line = format_serial_output(line);
+                        println!("{}", formatted_line);
+                    }
+
+                    // Handle partial lines (without newline)
+                    if !output.ends_with('\n') && !output.is_empty() {
+                        let last_part = output.lines().last().unwrap_or("");
+                        if !last_part.is_empty() {
+                            let formatted = format_serial_output(last_part);
+                            print!("{}", formatted);
+                        }
+                    }
+
+                    let _ = stdout().flush();
+                }
+                Ok(_) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("Error reading from serial port: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+
+    // Main thread handles user input
+    let stdin = stdin();
+    let mut input_buffer = String::new();
+    while running.load(Ordering::SeqCst) {
+        input_buffer.clear();
+        match stdin.read_line(&mut input_buffer) {
+            Ok(_) => {
+                if !running.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                if let Err(e) = serial.write_all(input_buffer.as_bytes()) {
+                    eprintln!("Error writing to serial port: {}", e);
+                    break;
+                }
+                let _ = serial.flush();
+            }
+            Err(e) => {
+                eprintln!("Error reading input: {}", e);
+                break;
+            }
+        }
+    }
+
+    running.store(false, Ordering::SeqCst);
+    let _ = read_handle.join();
+
+    println!("\n{}", "Serial console closed.".bright_green());
+}
+
+fn open_serial_monitor_only(_port: &str, mut serial: Box<dyn serialport::SerialPort>) {
+    let running = Arc::new(AtomicBool::new(true));
+    let running_clone = running.clone();
+
+    ctrlc::set_handler(move || {
+        running.store(false, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl+C handler");
+
+    let mut buffer = [0u8; 1024];
+    let mut line_buffer = String::new();
+
+    while running_clone.load(Ordering::SeqCst) {
+        match serial.read(&mut buffer) {
+            Ok(bytes_read) if bytes_read > 0 => {
+                let data = &buffer[..bytes_read];
+                let output = String::from_utf8_lossy(data);
+
+                for ch in output.chars() {
+                    match ch {
+                        '\n' => {
+                            let formatted_line = format_serial_output(&line_buffer);
+                            println!("{}", formatted_line);
+                            line_buffer.clear();
+                        }
+                        '\r' => {
+                            if !line_buffer.is_empty() {
+                                let formatted_line = format_serial_output(&line_buffer);
+                                print!("{}\r", formatted_line);
+                                let _ = stdout().flush();
+                                line_buffer.clear();
+                            }
+                        }
+                        c if c.is_control() => {
+                            continue;
+                        }
+                        c => {
+                            line_buffer.push(c);
+                        }
+                    }
+                }
+
+                if !line_buffer.is_empty() && !output.ends_with('\n') && !output.ends_with('\r') {
+                    let formatted_partial = format_serial_output(&line_buffer);
+                    print!("{}", formatted_partial);
+                    let _ = stdout().flush();
+                    line_buffer.clear();
+                }
+            }
+            Ok(_) => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+                continue;
+            }
+            Err(e) => {
+                println!("Error reading from serial port: {}", e);
+                break;
+            }
+        }
+    }
+
+    println!("\n{}", "Serial monitor closed.".bright_green());
+}
+
+fn handle_default_command(default_run: DefaultRun, config: &mut BlriConfig) {
+    // Check if we have saved configuration with binary path
+    if let Some(binary_path) = config.get_binary_path() {
+        if binary_path.exists() {
+            println!("📋 Using saved configuration:");
+            if let Some(target) = &config.target {
+                println!("  Target: {}", target);
+            }
+            println!("  Release: {}", if config.release { "Yes" } else { "No" });
+            if let Some(package) = &config.package {
+                println!("  Package: {}", package);
+            }
+            println!("  Binary: {}", binary_path.display());
+            println!();
+
+            // Use unified run logic
+            run_with_unified_config(
+                config,
+                &binary_path,
+                config.port.clone(),
+                Some(config.baudrate),
+                config.target.clone(),
+                config.release,
+                config.package.clone(),
+                default_run.reset.unwrap_or(config.reset),
+                default_run.console.unwrap_or(config.console),
+            );
+        } else {
+            println!(
+                "{}",
+                "❌ Saved configuration binary not found.".bright_red()
+            );
+            println!("Binary path: {}", binary_path.display());
+            println!("Available options:");
+            if let (Some(target), Some(package)) = (&config.target, &config.package) {
+                println!(
+                    "1. Build the project first: cargo build --target {} {} -p {}",
+                    target,
+                    if config.release { "--release" } else { "" },
+                    package
+                );
+            }
+        }
+    } else {
+        println!("{}", "❌ No saved configuration found.".bright_red());
+        println!("Please run with a target first to create a configuration:");
+        println!("  cargo run run <path-to-binary>");
+    }
+}
+
+/// Unified run function with two-step confirmation
+fn run_with_unified_config(
+    config: &mut BlriConfig,
+    input_file: &PathBuf,
+    port: Option<String>,
+    baudrate: Option<u32>,
+    target: Option<String>,
+    release: bool,
+    package: Option<String>,
+    reset: bool,
+    console: bool,
+) {
+    // Use provided port or select one
+    let (final_port, final_baudrate) = if let Some(port) = port {
+        (port, baudrate.unwrap_or(2000000))
+    } else {
+        use_or_select_flash_port_and_baudrate(&None, baudrate)
+    };
+
+    // Handle configuration conflicts and get decisions
+    let (use_current, should_save_after) = match config.handle_configuration_conflict(
+        &final_port,
+        final_baudrate,
+        target.clone(),
+        release,
+        package.clone(),
+        reset,
+        console,
+    ) {
+        Ok(result) => result,
+        Err(e) => {
+            println!("Error handling configuration: {}", e);
+            return;
+        }
+    };
+
+    // Determine which configuration to use for running
+    let (run_port, run_baudrate, run_reset, run_console) = if use_current {
+        // Use current (command line) configuration
+        (final_port.clone(), final_baudrate, reset, console)
+    } else {
+        // Use saved configuration
+        (
+            config.port.as_ref().unwrap_or(&final_port).clone(),
+            config.baudrate,
+            config.reset,
+            config.console,
+        )
+    };
+
+    println!("🚀 Running with configuration...");
+
+    // Convert ELF to BIN and patch
+    let bin_file = input_file.with_extension("bin");
+    elf_to_bin(&input_file, &bin_file).expect("convert ELF to BIN");
+    patch_image(&bin_file, &bin_file);
+
+    // Flash the image
+    match flash_image(&bin_file, &run_port, run_reset, run_baudrate) {
+        Ok(_) => {
+            // Open serial interface based on console setting
+            if run_console {
+                println!("Opening serial console on {}...", run_port);
+                open_serial_console(&run_port, true, run_baudrate);
+            } else {
+                println!("Opening serial monitor on {}...", run_port);
+                open_serial_console(&run_port, false, run_baudrate);
+            }
+
+            // Second confirmation: save configuration after successful run
+            if should_save_after {
+                if let Err(e) = config.save_after_run(
+                    &final_port,
+                    final_baudrate,
+                    target,
+                    release,
+                    package,
+                    reset,
+                    console,
+                ) {
+                    println!("Error saving configuration: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            println!("error: {}", e);
+            println!("Flashing failed. Serial interface will not be opened.");
+        }
+    }
+}
+
+fn handle_run_command(run: Run, config: &mut BlriConfig) {
+    // Check if input file is provided
+    let input_file = match run.input_file {
+        Some(file) => file,
+        None => {
+            // No input file provided, try to use saved configuration
+            if let Some(binary_path) = config.get_binary_path() {
+                if binary_path.exists() {
+                    println!("📋 Using saved configuration:");
+                    if let Some(target) = &config.target {
+                        println!("  Target: {}", target);
+                    }
+                    println!("  Release: {}", if config.release { "Yes" } else { "No" });
+                    if let Some(package) = &config.package {
+                        println!("  Package: {}", package);
+                    }
+                    println!("  Binary: {}", binary_path.display());
+                    println!();
+                    binary_path
+                } else {
+                    println!(
+                        "{}",
+                        "❌ No input file provided and saved configuration binary not found."
+                            .bright_red()
+                    );
+                    println!("Binary path: {}", binary_path.display());
+                    println!("Available options:");
+                    println!("1. Provide input file: cargo blri run <path-to-binary>");
+                    if let (Some(target), Some(package)) = (&config.target, &config.package) {
+                        println!(
+                            "2. Build the project first: cargo build --target {} {} -p {}",
+                            target,
+                            if config.release { "--release" } else { "" },
+                            package
+                        );
+                    }
+                    return;
+                }
+            } else {
+                println!(
+                    "{}",
+                    "❌ No input file provided and no saved configuration found.".bright_red()
+                );
+                println!("Please provide an input file or run with a target first.");
+                return;
+            }
+        }
+    };
+
+    // Extract build parameters from environment and binary path
+    let args: Vec<String> = std::env::args().collect();
+    println!("🔧 Program args: {:?}", args);
+
+    // Method 1: Try environment variables set by cargo
+    let mut target = None;
+    let mut package = None;
+    let mut release = false;
+
+    // Check all environment variables for debugging
+    let env_vars: Vec<(String, String)> = std::env::vars().collect();
+    for (key, value) in &env_vars {
+        if key.starts_with("CARGO_") {
+            println!("  {}: {}", key, value);
+        }
+    }
+
+    // Extract target from binary path
+    let binary_path = input_file.to_string_lossy();
+    println!("🔧 Binary path: {}", binary_path);
+
+    // Parse target from path like: target/riscv64imac-unknown-none-elf/release/uart-demo
+    let path_parts: Vec<&str> = binary_path.split('/').collect();
+
+    // Find target architecture
+    for (i, part) in path_parts.iter().enumerate() {
+        if *part == "target" && i + 1 < path_parts.len() {
+            let potential_target = path_parts[i + 1];
+            if potential_target.contains("-unknown-none-elf")
+                || potential_target == "debug"
+                || potential_target == "release"
+            {
+                if potential_target != "debug" && potential_target != "release" {
+                    target = Some(potential_target.to_string());
+                }
+            }
+        }
+    }
+
+    // Find release/debug mode
+    if binary_path.contains("/release/") {
+        release = true;
+    }
+
+    // Extract package name from binary file name
+    if let Some(file_name) = input_file.file_name() {
+        package = Some(file_name.to_string_lossy().to_string());
+    }
+
+    // Try environment variables as backup
+    if target.is_none() {
+        target = std::env::var("CARGO_CFG_TARGET_ARCH")
+            .ok()
+            .or_else(|| std::env::var("TARGET").ok());
+    }
+
+    if package.is_none() {
+        package = std::env::var("CARGO_PKG_NAME").ok();
+    }
+
+    if !release {
+        release = std::env::var("PROFILE")
+            .map(|p| p == "release")
+            .unwrap_or(false);
+    }
+
+    println!("🔧 Detected build parameters:");
+    println!("  Target: {:?}", target);
+    println!("  Release: {}", release);
+    println!("  Package: {:?}", package);
+    println!();
+
+    // Use unified run logic
+    run_with_unified_config(
+        config,
+        &input_file,
+        run.port,
+        None, // Let the function determine baudrate
+        target,
+        release,
+        package,
+        run.reset,
+        run.console,
+    );
+}
+
+// Helper function to extract argument values from command line
+#[allow(dead_code)]
+fn extract_arg_value(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|arg| arg == flag)
+        .and_then(|pos| args.get(pos + 1))
+        .cloned()
 }

--- a/blri/src/settings.rs
+++ b/blri/src/settings.rs
@@ -13,6 +13,7 @@ pub struct BlriConfig {
     pub baudrate: u32,
     pub reset: bool,
     pub console: bool,
+    pub verbose: bool,
 }
 
 impl Default for BlriConfig {
@@ -26,6 +27,7 @@ impl Default for BlriConfig {
             baudrate: 2000000,
             reset: false,
             console: false,
+            verbose: false,
         }
     }
 }
@@ -226,6 +228,7 @@ impl BlriConfig {
         package: Option<String>,
         reset: bool,
         console: bool,
+        verbose: bool,
     ) -> Result<(bool, bool), Box<dyn std::error::Error>> {
         // Check for conflicts with current configuration
         let mut conflicts = Vec::new();
@@ -274,6 +277,10 @@ impl BlriConfig {
             conflicts.push(format!("Console: {} -> {}", self.console, console));
         }
 
+        if self.verbose != verbose {
+            conflicts.push(format!("Verbose: {} -> {}", self.verbose, verbose));
+        }
+
         // If there are conflicts, ask first confirmation
         if !conflicts.is_empty() {
             println!();
@@ -316,6 +323,7 @@ impl BlriConfig {
         package: Option<String>,
         reset: bool,
         console: bool,
+        verbose: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Update configuration with current values
         self.port = Some(port.to_string());
@@ -325,6 +333,7 @@ impl BlriConfig {
         self.package = package;
         self.reset = reset;
         self.console = console;
+        self.verbose = verbose;
         self.update_binary_path();
 
         println!();

--- a/blri/src/settings.rs
+++ b/blri/src/settings.rs
@@ -1,0 +1,342 @@
+use colored::*;
+use inquire::Confirm;
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlriConfig {
+    pub target: Option<String>,
+    pub release: bool,
+    pub package: Option<String>,
+    pub binary_path: Option<String>, // Auto-generated from target/package/release
+    pub port: Option<String>,
+    pub baudrate: u32,
+    pub reset: bool,
+    pub console: bool,
+}
+
+impl Default for BlriConfig {
+    fn default() -> Self {
+        Self {
+            target: None,
+            release: false,
+            package: None,
+            binary_path: None,
+            port: None,
+            baudrate: 2000000,
+            reset: false,
+            console: false,
+        }
+    }
+}
+
+impl BlriConfig {
+    /// Get the path to the settings file
+    pub fn get_settings_path() -> Option<PathBuf> {
+        std::env::current_dir()
+            .ok()
+            .map(|current| current.join("target").join("settings.toml"))
+    }
+
+    /// Load configuration from file
+    pub fn load() -> Self {
+        if let Some(path) = Self::get_settings_path() {
+            if path.exists() {
+                if let Ok(content) = fs::read_to_string(&path) {
+                    if let Ok(config) = toml::from_str::<BlriConfig>(&content) {
+                        println!(
+                            "{} {}",
+                            "📋 Loaded configuration:".bright_blue().bold(),
+                            path.display()
+                        );
+                        Self::display_config(&config);
+                        return config;
+                    }
+                }
+            }
+        }
+        println!(
+            "{}",
+            "📋 No configuration found, using defaults".bright_yellow()
+        );
+        Self::default()
+    }
+
+    /// Save configuration to file
+    pub fn save(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(path) = Self::get_settings_path() {
+            // Update binary path before saving
+            self.update_binary_path();
+
+            // Create target directory if it doesn't exist
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            let content = toml::to_string_pretty(self)?;
+            fs::write(&path, content)?;
+
+            println!(
+                "{} {}",
+                "💾 Configuration saved to:".bright_green().bold(),
+                path.display()
+            );
+            Self::display_config(self);
+            Ok(())
+        } else {
+            Err("Cannot determine home directory".into())
+        }
+    }
+
+    /// Display current configuration
+    pub fn display_config(config: &BlriConfig) {
+        println!(
+            "  {}: {}",
+            "Target".bright_cyan(),
+            config.target.as_deref().unwrap_or("None").bright_white()
+        );
+        println!(
+            "  {}: {}",
+            "Release".bright_cyan(),
+            if config.release {
+                "Yes".bright_green()
+            } else {
+                "No".bright_red()
+            }
+        );
+        println!(
+            "  {}: {}",
+            "Package".bright_cyan(),
+            config.package.as_deref().unwrap_or("None").bright_white()
+        );
+        if let Some(binary_path) = &config.binary_path {
+            println!(
+                "  {}: {}",
+                "Binary".bright_cyan(),
+                binary_path.bright_white()
+            );
+        }
+        println!(
+            "  {}: {}",
+            "Port".bright_cyan(),
+            config.port.as_deref().unwrap_or("None").bright_white()
+        );
+        println!(
+            "  {}: {}",
+            "Baudrate".bright_cyan(),
+            config.baudrate.to_string().bright_white()
+        );
+        println!(
+            "  {}: {}",
+            "Reset".bright_cyan(),
+            if config.reset {
+                "Yes".bright_green()
+            } else {
+                "No".bright_red()
+            }
+        );
+        println!(
+            "  {}: {}",
+            "Console".bright_cyan(),
+            if config.console {
+                "Yes".bright_green()
+            } else {
+                "No".bright_red()
+            }
+        );
+        println!();
+    }
+
+    /// Check if configuration is complete for running
+    pub fn is_complete(&self) -> bool {
+        self.target.is_some() && self.package.is_some() && self.port.is_some()
+    }
+
+    /// Generate binary path from target, package, and release mode
+    pub fn generate_binary_path(&self) -> Option<PathBuf> {
+        if let (Some(target), Some(package)) = (&self.target, &self.package) {
+            let mode = if self.release { "release" } else { "debug" };
+
+            // Detect if we're in the blri subdirectory or project root
+            let current_dir = std::env::current_dir().ok()?;
+            let is_in_blri_dir = current_dir
+                .file_name()
+                .map(|name| name == "blri")
+                .unwrap_or(false);
+
+            let path = if is_in_blri_dir {
+                // From blri directory: ../target/...
+                format!("../target/{}/{}/{}", target, mode, package)
+            } else {
+                // From project root: target/...
+                format!("target/{}/{}/{}", target, mode, package)
+            };
+
+            Some(PathBuf::from(path))
+        } else {
+            None
+        }
+    }
+
+    /// Update binary path based on current target, package, and release settings
+    pub fn update_binary_path(&mut self) {
+        self.binary_path = self
+            .generate_binary_path()
+            .map(|p| p.to_string_lossy().to_string());
+    }
+
+    /// Get the binary path as PathBuf, generating it if needed
+    pub fn get_binary_path(&self) -> Option<PathBuf> {
+        // First try the stored binary_path, but check if it exists
+        if let Some(binary_path) = &self.binary_path {
+            let path = PathBuf::from(binary_path);
+            if path.exists() {
+                return Some(path);
+            }
+
+            // If stored path doesn't exist, try converting between ../target and target
+            let alternative_path = if binary_path.starts_with("../target/") {
+                // Convert ../target to target (from blri dir to root dir)
+                PathBuf::from(binary_path.strip_prefix("../").unwrap_or(binary_path))
+            } else if binary_path.starts_with("target/") {
+                // Convert target to ../target (from root dir to blri dir)
+                PathBuf::from(format!("../{}", binary_path))
+            } else {
+                path
+            };
+
+            if alternative_path.exists() {
+                return Some(alternative_path);
+            }
+        }
+
+        // If stored path doesn't exist or is None, generate from components
+        self.generate_binary_path()
+    }
+
+    /// Merge with command line arguments and ask whether to use current configuration
+    /// Unified configuration management with two-step confirmation
+    /// Returns (use_current_config, should_save_after_run)
+    pub fn handle_configuration_conflict(
+        &mut self,
+        port: &str,
+        baudrate: u32,
+        target: Option<String>,
+        release: bool,
+        package: Option<String>,
+        reset: bool,
+        console: bool,
+    ) -> Result<(bool, bool), Box<dyn std::error::Error>> {
+        // Check for conflicts with current configuration
+        let mut conflicts = Vec::new();
+
+        if self.port.as_deref() != Some(port) {
+            conflicts.push(format!(
+                "Port: {} -> {}",
+                self.port.as_deref().unwrap_or("None"),
+                port
+            ));
+        }
+
+        if self.baudrate != baudrate {
+            conflicts.push(format!("Baudrate: {} -> {}", self.baudrate, baudrate));
+        }
+
+        if let Some(new_target) = &target {
+            if self.target.as_ref() != Some(new_target) {
+                conflicts.push(format!(
+                    "Target: {} -> {}",
+                    self.target.as_deref().unwrap_or("None"),
+                    new_target
+                ));
+            }
+        }
+
+        if self.release != release {
+            conflicts.push(format!("Release: {} -> {}", self.release, release));
+        }
+
+        if let Some(new_package) = &package {
+            if self.package.as_ref() != Some(new_package) {
+                conflicts.push(format!(
+                    "Package: {} -> {}",
+                    self.package.as_deref().unwrap_or("None"),
+                    new_package
+                ));
+            }
+        }
+
+        if self.reset != reset {
+            conflicts.push(format!("Reset: {} -> {}", self.reset, reset));
+        }
+
+        if self.console != console {
+            conflicts.push(format!("Console: {} -> {}", self.console, console));
+        }
+
+        // If there are conflicts, ask first confirmation
+        if !conflicts.is_empty() {
+            println!();
+            println!(
+                "{}",
+                "⚠️  Configuration conflicts detected:"
+                    .bright_yellow()
+                    .bold()
+            );
+            for conflict in &conflicts {
+                println!("  {}", conflict.bright_white());
+            }
+            println!();
+
+            let use_current =
+                Confirm::new("Use current configuration instead of saved configuration?")
+                    .with_default(true)
+                    .prompt()?;
+
+            if use_current {
+                // User wants to use current config, prepare for potential save after run
+                return Ok((true, true));
+            } else {
+                // User wants to use saved config, no save needed
+                return Ok((false, false));
+            }
+        }
+
+        // No conflicts, use current config and maybe save if it's new
+        Ok((true, false))
+    }
+
+    /// Save current configuration after successful run (second confirmation)
+    pub fn save_after_run(
+        &mut self,
+        port: &str,
+        baudrate: u32,
+        target: Option<String>,
+        release: bool,
+        package: Option<String>,
+        reset: bool,
+        console: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Update configuration with current values
+        self.port = Some(port.to_string());
+        self.baudrate = baudrate;
+        self.target = target;
+        self.release = release;
+        self.package = package;
+        self.reset = reset;
+        self.console = console;
+        self.update_binary_path();
+
+        println!();
+        let should_save = Confirm::new("Save current configuration for future use?")
+            .with_default(true)
+            .prompt()?;
+
+        if should_save {
+            self.save()?;
+            println!("{}", "✅ Configuration saved successfully!".bright_green());
+        }
+
+        Ok(())
+    }
+}

--- a/bouffalo-hal/src/efuse/register.rs
+++ b/bouffalo-hal/src/efuse/register.rs
@@ -878,8 +878,8 @@ where
         &self,
         dev: TrimDev,
         reload: bool,
-        _glb: Option<&glb::v1::RegisterBlock>,
-        _hbn: Option<&hbn::RegisterBlock>,
+        glb: Option<&glb::v1::RegisterBlock>,
+        hbn: Option<&hbn::RegisterBlock>,
     ) -> Result<TrimData, EfuseError> {
         // Find trim configuration for the device
         let trim_cfg = match get_trim_cfg_by_dev(dev) {
@@ -901,8 +901,8 @@ where
 
         // For BL602/BL702, save and switch CPU clock
         #[cfg(any(feature = "bl702", feature = "bl602"))]
-        let clock_state = if let (Some(glb_reg), Some(hbn_reg)) = (_glb, _hbn) {
-            Some(efuse_switch_cpu_clock_save(_glb_reg, hbn_reg))
+        let clock_state = if let (Some(glb_reg), Some(hbn_reg)) = (glb, hbn) {
+            Some(efuse_switch_cpu_clock_save(glb_reg, hbn_reg))
         } else {
             None
         };

--- a/bouffalo-hal/src/efuse/register.rs
+++ b/bouffalo-hal/src/efuse/register.rs
@@ -878,8 +878,8 @@ where
         &self,
         dev: TrimDev,
         reload: bool,
-        glb: Option<&glb::v1::RegisterBlock>,
-        hbn: Option<&hbn::RegisterBlock>,
+        _glb: Option<&glb::v1::RegisterBlock>,
+        _hbn: Option<&hbn::RegisterBlock>,
     ) -> Result<TrimData, EfuseError> {
         // Find trim configuration for the device
         let trim_cfg = match get_trim_cfg_by_dev(dev) {
@@ -901,8 +901,8 @@ where
 
         // For BL602/BL702, save and switch CPU clock
         #[cfg(any(feature = "bl702", feature = "bl602"))]
-        let clock_state = if let (Some(glb_reg), Some(hbn_reg)) = (glb, hbn) {
-            Some(efuse_switch_cpu_clock_save(glb_reg, hbn_reg))
+        let clock_state = if let (Some(glb_reg), Some(hbn_reg)) = (_glb, _hbn) {
+            Some(efuse_switch_cpu_clock_save(_glb_reg, hbn_reg))
         } else {
             None
         };

--- a/bouffalo-hal/src/gpip.rs
+++ b/bouffalo-hal/src/gpip.rs
@@ -1,7 +1,9 @@
 //! Generic DAC, ADC and ACOMP interface control peripheral.
 
 mod adc;
+pub mod asynch;
 mod register;
 
 pub use adc::*;
+pub use asynch::*;
 pub use register::*;

--- a/bouffalo-hal/src/gpip/asynch.rs
+++ b/bouffalo-hal/src/gpip/asynch.rs
@@ -139,7 +139,12 @@ impl AdcState {
     /// Use this waker set to handle ADC interrupt.
     #[inline]
     pub fn on_interrupt(&self) {
-        let gpip = unsafe { &*(self.ref_to_gpip.load(Ordering::Acquire) as *const RegisterBlock) };
+        let ptr = self.ref_to_gpip.load(Ordering::Acquire);
+        if ptr == 0 {
+            // Pointer is invalid; do not attempt to dereference.
+            return;
+        }
+        let gpip = unsafe { &*(ptr as *const RegisterBlock) };
 
         // Check interrupt status
         let int_ready = gpip.gpadc_config.read().is_adc_ready();

--- a/bouffalo-hal/src/gpip/asynch.rs
+++ b/bouffalo-hal/src/gpip/asynch.rs
@@ -1,0 +1,184 @@
+use super::{AdcChannels, AdcCommand, AdcIntStatus, AdcResult, Gpip, RegisterBlock};
+use crate::hbn;
+use core::{
+    future::Future,
+    ops::Deref,
+    pin::Pin,
+    sync::atomic::{AtomicUsize, Ordering},
+    task::{Context, Poll},
+};
+
+/// Error type for ADC operations
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AdcError {
+    /// Conversion timeout
+    Timeout,
+    /// Hardware error
+    HardwareError,
+}
+
+/// Managed async/await ADC peripheral.
+pub struct AsyncAdc<'a, G: Deref<Target = RegisterBlock>> {
+    gpip: &'a mut Gpip<G>,
+    state: &'a AdcState,
+}
+
+impl<'a, G: Deref<Target = RegisterBlock>> AsyncAdc<'a, G> {
+    /// Creates the async/await ADC peripheral from owned GPIP structure and state.
+    #[inline]
+    pub fn new(gpip: &'a mut Gpip<G>, state: &'a AdcState) -> Self {
+        // Store reference to GPIP register block for interrupt handling
+        state
+            .ref_to_gpip
+            .store(&**gpip as *const _ as usize, Ordering::Release);
+
+        AsyncAdc { gpip, state }
+    }
+
+    /// Start ADC conversion with async/await support.
+    pub async fn convert(
+        &mut self,
+        channels: &[AdcChannels],
+        hbn: &hbn::RegisterBlock,
+        results: &mut [AdcResult],
+    ) -> Result<usize, AdcError> {
+        if channels.is_empty() || results.is_empty() {
+            return Ok(0);
+        }
+
+        // Clear FIFO first
+        self.gpip
+            .adc_feature_control(AdcCommand::ClearFifo, false, hbn);
+
+        // Configure channels
+        self.gpip.adc_channel_config(channels, hbn);
+
+        // Enable ADC interrupt
+        self.gpip.adc_rxint_mask(false);
+
+        // Start conversion
+        self.gpip.adc_start_conversion(hbn);
+
+        // Wait for conversion completion using true interrupt-driven async
+        WaitForAdcReady::new(&**self.gpip, &self.state.adc_ready).await;
+
+        // Read results
+        let count = core::cmp::min(self.gpip.adc_get_complete_num() as usize, results.len());
+
+        // If count is 0, conversion didn't complete normally, try polling mode as fallback
+        let final_count = if count == 0 {
+            // Fallback plan: short-term polling wait
+            for _ in 0..10000 {
+                let current_count = self.gpip.adc_get_complete_num() as usize;
+                if current_count > 0 {
+                    break;
+                }
+                core::hint::spin_loop();
+            }
+            core::cmp::min(self.gpip.adc_get_complete_num() as usize, results.len())
+        } else {
+            count
+        };
+
+        let mut actual_count = 0;
+
+        for _ in 0..final_count {
+            let raw_data = self.gpip.adc_get_raw_data();
+
+            // Use the proper parsing method from GPIP
+            let mut temp_results = [AdcResult {
+                pos_chan: channels.get(0).map(|c| c.pos_ch),
+                neg_chan: channels.get(0).map(|c| c.neg_ch),
+                value: 0,
+                millivolt: 0,
+            }; 1];
+
+            // Parse the result properly
+            self.gpip
+                .adc_parse_result(&[raw_data], &mut temp_results, hbn);
+
+            results[actual_count] = temp_results[0];
+            actual_count += 1;
+        }
+
+        // Clear interrupt
+        let clear_flags = AdcIntStatus {
+            adc_ready: true,
+            fifo_underrun: false,
+            fifo_overrun: false,
+            neg_saturation: false,
+            pos_saturation: false,
+        };
+        self.gpip.adc_int_clear(clear_flags, hbn);
+
+        // Stop conversion and mask interrupt
+        self.gpip.adc_stop_conversion(hbn);
+        self.gpip.adc_rxint_mask(true);
+
+        Ok(actual_count)
+    }
+}
+
+/// Set of wakers as the state for an async/await ADC peripheral.
+#[derive(Debug)]
+pub struct AdcState {
+    adc_ready: atomic_waker::AtomicWaker,
+    ref_to_gpip: AtomicUsize,
+}
+
+impl AdcState {
+    /// Creates the set of wakers for an ADC peripheral.
+    #[inline]
+    pub const fn new() -> AdcState {
+        AdcState {
+            adc_ready: atomic_waker::AtomicWaker::new(),
+            ref_to_gpip: AtomicUsize::new(0),
+        }
+    }
+
+    /// Use this waker set to handle ADC interrupt.
+    #[inline]
+    pub fn on_interrupt(&self) {
+        let gpip = unsafe { &*(self.ref_to_gpip.load(Ordering::Acquire) as *const RegisterBlock) };
+
+        // Check interrupt status
+        let int_ready = gpip.gpadc_config.read().is_adc_ready();
+
+        // Wake up waiting tasks if ADC is ready
+        if int_ready {
+            self.adc_ready.wake();
+        }
+    }
+}
+
+/// Future that waits for ADC ready interrupt.
+struct WaitForAdcReady<'r> {
+    gpip: &'r RegisterBlock,
+    registry: &'r atomic_waker::AtomicWaker,
+}
+
+impl<'r> WaitForAdcReady<'r> {
+    #[inline]
+    pub const fn new(gpip: &'r RegisterBlock, registry: &'r atomic_waker::AtomicWaker) -> Self {
+        Self { gpip, registry }
+    }
+}
+
+impl Future for WaitForAdcReady<'_> {
+    type Output = ();
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // First check if ADC has already completed
+        let int_ready = self.gpip.gpadc_config.read().is_adc_ready();
+
+        if int_ready {
+            // ADC has completed, clear interrupt flag and return Ready
+            Poll::Ready(())
+        } else {
+            // ADC not completed, register waker to wait for interrupt wake-up
+            self.registry.register(cx.waker());
+            Poll::Pending
+        }
+    }
+}

--- a/bouffalo-hal/src/gpip/register.rs
+++ b/bouffalo-hal/src/gpip/register.rs
@@ -478,8 +478,8 @@ where
     pub(crate) adc_reference_channel: Option<GpadcChannel>,
     pub(crate) adc_reference_mv: i32,
     pub(crate) tsen_offset: u32,
-    pub(crate) dac_config: Option<DacConfig>,
-    pub(crate) dac_calibration_complete: bool,
+    pub(crate) _dac_config: Option<DacConfig>,
+    pub(crate) _dac_calibration_complete: bool,
 }
 
 impl<G: Deref<Target = RegisterBlock>> Gpip<G> {
@@ -488,7 +488,7 @@ impl<G: Deref<Target = RegisterBlock>> Gpip<G> {
     pub fn new(
         gpip: G,
         adc_config: Option<AdcConfig>,
-        dac_config: Option<DacConfig>,
+        _dac_config: Option<DacConfig>,
         glb: &glb::v2::RegisterBlock,
         hbn: &hbn::RegisterBlock,
     ) -> Self {
@@ -635,8 +635,8 @@ impl<G: Deref<Target = RegisterBlock>> Gpip<G> {
             adc_reference_channel: None,
             adc_reference_mv: -1,
             tsen_offset: 0,
-            dac_config,
-            dac_calibration_complete: false,
+            _dac_config,
+            _dac_calibration_complete: false,
         }
     }
 }

--- a/bouffalo-hal/src/hbn.rs
+++ b/bouffalo-hal/src/hbn.rs
@@ -2117,10 +2117,28 @@ impl GpadcInterruptState {
     pub fn is_neg_satur_interrupt_enabled(self) -> bool {
         self.0 & Self::NEG_SATUR_MASK == 0
     }
+    /// Set positive saturation interrupt bit.
+    #[inline]
+    pub fn set_pos_satur_interrupt(self, set: bool) -> Self {
+        Self(if set {
+            self.0 | Self::POS_SATUR
+        } else {
+            self.0 & !Self::POS_SATUR
+        })
+    }
     /// Clear positive saturation interrupt.
     #[inline]
     pub fn clear_pos_satur_interrupt(self) -> Self {
         Self(self.0 | Self::POS_SATUR_CLR)
+    }
+    /// Set negative saturation interrupt bit.
+    #[inline]
+    pub fn set_neg_satur_interrupt(self, set: bool) -> Self {
+        Self(if set {
+            self.0 | Self::NEG_SATUR
+        } else {
+            self.0 & !Self::NEG_SATUR
+        })
     }
     /// Clear negative saturation interrupt.
     #[inline]

--- a/bouffalo-hal/src/uart/asynch.rs
+++ b/bouffalo-hal/src/uart/asynch.rs
@@ -76,8 +76,12 @@ impl SerialState {
     /// Use this waker set to handle interrupt.
     #[inline]
     pub fn on_interrupt(&self) {
-        let uart =
-            unsafe { &*(self.ref_to_serial.load(Ordering::Acquire) as *const RegisterBlock) };
+        let ptr = self.ref_to_serial.load(Ordering::Acquire);
+        if ptr == 0 {
+            // Pointer is invalid; do not attempt to dereference.
+            return;
+        }
+        let uart = unsafe { &*(ptr as *const RegisterBlock) };
         let state = uart.interrupt_state.read();
         for (interrupt, waker) in [
             (Interrupt::ReceiveFifoReady, &self.receive_ready),

--- a/bouffalo-rt/build.rs
+++ b/bouffalo-rt/build.rs
@@ -155,7 +155,75 @@ SECTIONS {
     /DISCARD/ : {
         *(.eh_frame)
     }
-}";
+}
+/* exceptions */
+PROVIDE(exceptions = default_handler);
+/* interrupts */
+PROVIDE(bmx_mcu_bus_err = default_handler);
+PROVIDE(bmx_mcu_to = default_handler);
+PROVIDE(m0_reserved2 = default_handler);
+PROVIDE(ipc_m0 = default_handler);
+PROVIDE(audio = default_handler);
+PROVIDE(rf_top_int0 = default_handler);
+PROVIDE(rf_top_int1 = default_handler);
+PROVIDE(lz4d = default_handler);
+PROVIDE(gauge_itf = default_handler);
+PROVIDE(sec_eng_id1_sha_aes_trng_pka_gmac = default_handler);
+PROVIDE(sec_eng_id0_sha_aes_trng_pka_gmac = default_handler);
+PROVIDE(sec_eng_id1_cdet = default_handler);
+PROVIDE(sec_eng_id0_cdet = default_handler);
+PROVIDE(sf_ctrl_id1 = default_handler);
+PROVIDE(sf_ctrl_id0 = default_handler);
+PROVIDE(dma0_all = default_handler);
+PROVIDE(dma1_all = default_handler);
+PROVIDE(sdh = default_handler);
+PROVIDE(mm_all = default_handler);
+PROVIDE(irtx = default_handler);
+PROVIDE(irrx = default_handler);
+PROVIDE(usb = default_handler);
+PROVIDE(aupdm_touch = default_handler);
+PROVIDE(m0_reserved23 = default_handler);
+PROVIDE(emac = default_handler);
+PROVIDE(gpadc_dma = default_handler);
+PROVIDE(efuse = default_handler);
+PROVIDE(spi0 = default_handler);
+PROVIDE(uart0 = default_handler);
+PROVIDE(uart1 = default_handler);
+PROVIDE(uart2 = default_handler);
+PROVIDE(gpio_dma = default_handler);
+PROVIDE(i2c0 = default_handler);
+PROVIDE(pwm = default_handler);
+PROVIDE(ipc_rsvd = default_handler);
+PROVIDE(ipc_lp = default_handler);
+PROVIDE(timer0_ch0 = default_handler);
+PROVIDE(timer0_ch1 = default_handler);
+PROVIDE(timer0_wdt = default_handler);
+PROVIDE(i2c1 = default_handler);
+PROVIDE(i2s = default_handler);
+PROVIDE(ana_ocp_out_to_cpu_0 = default_handler);
+PROVIDE(ana_ocp_out_to_cpu_1 = default_handler);
+PROVIDE(ana_ocp_out_to_cpu_2 = default_handler);
+PROVIDE(gpio_int0 = default_handler);
+PROVIDE(dm = default_handler);
+PROVIDE(bt = default_handler);
+PROVIDE(m154_req_ack = default_handler);
+PROVIDE(m154_int = default_handler);
+PROVIDE(m154_aes = default_handler);
+PROVIDE(pds_wakeup = default_handler);
+PROVIDE(hbn_out0 = default_handler);
+PROVIDE(hbn_out1 = default_handler);
+PROVIDE(bor = default_handler);
+PROVIDE(wifi = default_handler);
+PROVIDE(bz_phy_int = default_handler);
+PROVIDE(ble = default_handler);
+PROVIDE(mac_txrx_timer = default_handler);
+PROVIDE(mac_txrx_misc = default_handler);
+PROVIDE(mac_rx_trg = default_handler);
+PROVIDE(mac_tx_trg = default_handler);
+PROVIDE(mac_gen = default_handler);
+PROVIDE(mac_port_trg = default_handler);
+PROVIDE(wifi_ipc_public = default_handler);
+";
 
 #[cfg(feature = "bl808-dsp")]
 const LINKER_SCRIPT_BL808_DSP: &[u8] = b"
@@ -369,7 +437,75 @@ SECTIONS {
     /DISCARD/ : {
         *(.eh_frame)
     }
-}";
+}
+/* exceptions */
+PROVIDE(exceptions = default_handler);
+/* interrupts */
+PROVIDE(bmx_mcu_bus_err = default_handler);
+PROVIDE(bmx_mcu_to = default_handler);
+PROVIDE(m0_reserved2 = default_handler);
+PROVIDE(ipc_m0 = default_handler);
+PROVIDE(audio = default_handler);
+PROVIDE(rf_top_int0 = default_handler);
+PROVIDE(rf_top_int1 = default_handler);
+PROVIDE(lz4d = default_handler);
+PROVIDE(gauge_itf = default_handler);
+PROVIDE(sec_eng_id1_sha_aes_trng_pka_gmac = default_handler);
+PROVIDE(sec_eng_id0_sha_aes_trng_pka_gmac = default_handler);
+PROVIDE(sec_eng_id1_cdet = default_handler);
+PROVIDE(sec_eng_id0_cdet = default_handler);
+PROVIDE(sf_ctrl_id1 = default_handler);
+PROVIDE(sf_ctrl_id0 = default_handler);
+PROVIDE(dma0_all = default_handler);
+PROVIDE(dma1_all = default_handler);
+PROVIDE(sdh = default_handler);
+PROVIDE(mm_all = default_handler);
+PROVIDE(irtx = default_handler);
+PROVIDE(irrx = default_handler);
+PROVIDE(usb = default_handler);
+PROVIDE(aupdm_touch = default_handler);
+PROVIDE(m0_reserved23 = default_handler);
+PROVIDE(emac = default_handler);
+PROVIDE(gpadc_dma = default_handler);
+PROVIDE(efuse = default_handler);
+PROVIDE(spi0 = default_handler);
+PROVIDE(uart0 = default_handler);
+PROVIDE(uart1 = default_handler);
+PROVIDE(uart2 = default_handler);
+PROVIDE(gpio_dma = default_handler);
+PROVIDE(i2c0 = default_handler);
+PROVIDE(pwm = default_handler);
+PROVIDE(ipc_rsvd = default_handler);
+PROVIDE(ipc_lp = default_handler);
+PROVIDE(timer0_ch0 = default_handler);
+PROVIDE(timer0_ch1 = default_handler);
+PROVIDE(timer0_wdt = default_handler);
+PROVIDE(i2c1 = default_handler);
+PROVIDE(i2s = default_handler);
+PROVIDE(ana_ocp_out_to_cpu_0 = default_handler);
+PROVIDE(ana_ocp_out_to_cpu_1 = default_handler);
+PROVIDE(ana_ocp_out_to_cpu_2 = default_handler);
+PROVIDE(gpio_int0 = default_handler);
+PROVIDE(dm = default_handler);
+PROVIDE(bt = default_handler);
+PROVIDE(m154_req_ack = default_handler);
+PROVIDE(m154_int = default_handler);
+PROVIDE(m154_aes = default_handler);
+PROVIDE(pds_wakeup = default_handler);
+PROVIDE(hbn_out0 = default_handler);
+PROVIDE(hbn_out1 = default_handler);
+PROVIDE(bor = default_handler);
+PROVIDE(wifi = default_handler);
+PROVIDE(bz_phy_int = default_handler);
+PROVIDE(ble = default_handler);
+PROVIDE(mac_txrx_timer = default_handler);
+PROVIDE(mac_txrx_misc = default_handler);
+PROVIDE(mac_rx_trg = default_handler);
+PROVIDE(mac_tx_trg = default_handler);
+PROVIDE(mac_gen = default_handler);
+PROVIDE(mac_port_trg = default_handler);
+PROVIDE(wifi_ipc_public = default_handler);
+";
 
 #[cfg(feature = "bl702")]
 const LINKER_SCRIPT_BL702: &[u8] = b"

--- a/bouffalo-rt/macros/src/soc.rs
+++ b/bouffalo-rt/macros/src/soc.rs
@@ -4,18 +4,39 @@ use proc_macro2::Ident;
 use syn::parse::Error;
 
 pub fn check_interrupt_name(ident: &Ident) -> Option<Error> {
-    #[cfg(feature = "bl808-dsp")]
-    if !bl808::BL808_DSP_INTERRUPTS.contains(&format!("{}", ident).as_str()) {
-        return Some(Error::new(
-            ident.span(),
-            format!(
-                "invalid `#[interrupt]` source. Must be one of: {}.",
-                bl808::BL808_DSP_INTERRUPTS.join(", ")
-            ),
-        ));
+    #[cfg(all(
+        feature = "bl808-dsp",
+        not(feature = "bl808-mcu"),
+        not(feature = "bl808-lp")
+    ))]
+    {
+        if !bl808::BL808_DSP_INTERRUPTS.contains(&format!("{}", ident).as_str()) {
+            return Some(Error::new(
+                ident.span(),
+                format!(
+                    "invalid `#[interrupt]` source. Must be one of: {}.",
+                    bl808::BL808_DSP_INTERRUPTS.join(", ")
+                ),
+            ));
+        }
+    }
+    #[cfg(all(
+        any(feature = "bl808-mcu", feature = "bl808-lp"),
+        not(feature = "bl808-dsp")
+    ))]
+    {
+        if !bl808::BL808_MCU_LP_INTERRUPTS.contains(&format!("{}", ident).as_str()) {
+            return Some(Error::new(
+                ident.span(),
+                format!(
+                    "invalid `#[interrupt]` source. Must be one of: {}.",
+                    bl808::BL808_MCU_LP_INTERRUPTS.join(", ")
+                ),
+            ));
+        }
     }
     // TODO: support for other chips and contexts
-    #[cfg(not(feature = "bl808-dsp"))]
+    #[cfg(not(any(feature = "bl808-dsp", feature = "bl808-mcu", feature = "bl808-lp")))]
     let _ = ident;
     None
 }

--- a/bouffalo-rt/macros/src/soc.rs
+++ b/bouffalo-rt/macros/src/soc.rs
@@ -3,16 +3,16 @@ mod bl808;
 use proc_macro2::Ident;
 use syn::parse::Error;
 
-pub fn check_interrupt_name(ident: &Ident) -> Option<Error> {
+pub fn check_interrupt_name(_ident: &Ident) -> Option<Error> {
     #[cfg(all(
         feature = "bl808-dsp",
         not(feature = "bl808-mcu"),
         not(feature = "bl808-lp")
     ))]
     {
-        if !bl808::BL808_DSP_INTERRUPTS.contains(&format!("{}", ident).as_str()) {
+        if !bl808::BL808_DSP_INTERRUPTS.contains(&format!("{}", _ident).as_str()) {
             return Some(Error::new(
-                ident.span(),
+                _ident.span(),
                 format!(
                     "invalid `#[interrupt]` source. Must be one of: {}.",
                     bl808::BL808_DSP_INTERRUPTS.join(", ")
@@ -25,9 +25,9 @@ pub fn check_interrupt_name(ident: &Ident) -> Option<Error> {
         not(feature = "bl808-dsp")
     ))]
     {
-        if !bl808::BL808_MCU_LP_INTERRUPTS.contains(&format!("{}", ident).as_str()) {
+        if !bl808::BL808_MCU_LP_INTERRUPTS.contains(&format!("{}", _ident).as_str()) {
             return Some(Error::new(
-                ident.span(),
+                _ident.span(),
                 format!(
                     "invalid `#[interrupt]` source. Must be one of: {}.",
                     bl808::BL808_MCU_LP_INTERRUPTS.join(", ")
@@ -37,6 +37,6 @@ pub fn check_interrupt_name(ident: &Ident) -> Option<Error> {
     }
     // TODO: support for other chips and contexts
     #[cfg(not(any(feature = "bl808-dsp", feature = "bl808-mcu", feature = "bl808-lp")))]
-    let _ = ident;
+    let _ = _ident;
     None
 }

--- a/bouffalo-rt/macros/src/soc/bl808.rs
+++ b/bouffalo-rt/macros/src/soc/bl808.rs
@@ -1,5 +1,6 @@
 #[rustfmt::skip]
 #[cfg(feature = "bl808-dsp")]
+#[allow(dead_code)]
 pub(crate) const BL808_DSP_INTERRUPTS: [&'static str; 67] = [
     "bmx_dsp_bus_err",	"dsp_reserved1",	"dsp_reserved2",	"dsp_reserved3",	"uart3",
     "i2c2",	            "i2c3",	            "spi1",	            "dsp_reserved4",	"dsp_reserved5",
@@ -20,6 +21,7 @@ pub(crate) const BL808_DSP_INTERRUPTS: [&'static str; 67] = [
 // MCU and LP cores share the same interrupt sources (MCU is M0, LP is Low Power)
 #[rustfmt::skip]
 #[cfg(any(feature = "bl808-mcu", feature = "bl808-lp"))]
+#[allow(dead_code)]
 pub(crate) const BL808_MCU_LP_INTERRUPTS: [&'static str; 64] = [
     "bmx_mcu_bus_err",      "bmx_mcu_to",           "m0_reserved2",         "ipc_m0",
     "audio",                "rf_top_int0",          "rf_top_int1",          "lz4d",

--- a/bouffalo-rt/macros/src/soc/bl808.rs
+++ b/bouffalo-rt/macros/src/soc/bl808.rs
@@ -17,6 +17,24 @@ pub(crate) const BL808_DSP_INTERRUPTS: [&'static str; 67] = [
     "wl_all",	        "pds",
 ];
 
-// TODO const BL808_MCU_INTERRUPTS
-
-// TODO const BL808_LP_INTERRUPTS
+// MCU and LP cores share the same interrupt sources (MCU is M0, LP is Low Power)
+#[rustfmt::skip]
+#[cfg(any(feature = "bl808-mcu", feature = "bl808-lp"))]
+pub(crate) const BL808_MCU_LP_INTERRUPTS: [&'static str; 64] = [
+    "bmx_mcu_bus_err",      "bmx_mcu_to",           "m0_reserved2",         "ipc_m0",
+    "audio",                "rf_top_int0",          "rf_top_int1",          "lz4d",
+    "gauge_itf",            "sec_eng_id1_sha_aes_trng_pka_gmac", "sec_eng_id0_sha_aes_trng_pka_gmac", "sec_eng_id1_cdet",
+    "sec_eng_id0_cdet",     "sf_ctrl_id1",          "sf_ctrl_id0",          "dma0_all",
+    "dma1_all",             "sdh",                  "mm_all",               "irtx",
+    "irrx",                 "usb",                  "aupdm_touch",          "m0_reserved23",
+    "emac",                 "gpadc_dma",            "efuse",                "spi0",
+    "uart0",                "uart1",                "uart2",                "gpio_dma",
+    "i2c0",                 "pwm",                  "ipc_rsvd",             "ipc_lp",
+    "timer0_ch0",           "timer0_ch1",           "timer0_wdt",           "i2c1",
+    "i2s",                  "ana_ocp_out_to_cpu_0", "ana_ocp_out_to_cpu_1", "ana_ocp_out_to_cpu_2",
+    "gpio_int0",            "dm",                   "bt",                   "m154_req_ack",
+    "m154_int",             "m154_aes",             "pds_wakeup",           "hbn_out0",
+    "hbn_out1",             "bor",                  "wifi",                 "bz_phy_int",
+    "ble",                  "mac_txrx_timer",       "mac_txrx_misc",        "mac_rx_trg",
+    "mac_tx_trg",           "mac_gen",              "mac_port_trg",         "wifi_ipc_public",
+];

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,3 +23,5 @@
 | `adc-poll-onechan-demo`       | √     |
 | `adc-vbat-demo`       | √     |
 | `adc-tsen-demo`       | √     |
+| `adc-dma-demo`       | √     |
+| `adc-async-demo`       | √     |

--- a/examples/peripherals/adc-async-demo/Cargo.toml
+++ b/examples/peripherals/adc-async-demo/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "adc-async-demo"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
+bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-mcu"] }
+panic-halt = "1.0.0"
+embedded-time = "0.12.1"
+riscv = "0.13.0"
+
+[[bin]]
+name = "adc-async-demo"
+test = false

--- a/examples/peripherals/adc-async-demo/README.md
+++ b/examples/peripherals/adc-async-demo/README.md
@@ -1,0 +1,16 @@
+# ADC async demo
+
+## Build this example for `M0` core
+
+```bash
+rustup target install riscv32imac-unknown-none-elf
+cargo build --target riscv32imac-unknown-none-elf --release -p adc-async-demo
+```
+
+Compile the binary with:
+
+```bash
+rust-objcopy --binary-architecture=riscv32 --strip-all -O binary ./target/riscv32imac-unknown-none-elf/release/adc-async-demo ./target/riscv32imac-unknown-none-elf/release/adc-async-demo.bin
+```
+
+Open BL Dev Cube GUI, choose `M0` group, address `0x58000000`, then flash the binary to the board.

--- a/examples/peripherals/adc-async-demo/build.rs
+++ b/examples/peripherals/adc-async-demo/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tbouffalo-rt.ld");
+}

--- a/examples/peripherals/adc-async-demo/src/main.rs
+++ b/examples/peripherals/adc-async-demo/src/main.rs
@@ -1,0 +1,134 @@
+#![no_std]
+#![no_main]
+
+use bouffalo_hal::{
+    efuse::Efuse,
+    gpip::{
+        AdcChannels, AdcConfig, AdcResult, Gpip,
+        asynch::{AdcState, AsyncAdc},
+    },
+    hbn::{GpadcChannel, GpadcVref},
+    prelude::*,
+    uart::Config,
+};
+use bouffalo_rt::{
+    Clocks, Peripherals, entry, interrupt,
+    soc::bl808::{M0Machine, McuLpInterrupt},
+};
+use core::{
+    future::Future,
+    task::{Context, Poll, Waker},
+};
+use embedded_time::rate::*;
+use panic_halt as _;
+
+static ADC_STATE: AdcState = AdcState::new();
+
+#[interrupt]
+fn gpadc_dma() {
+    ADC_STATE.on_interrupt();
+}
+
+async fn async_main(p: Peripherals, c: Clocks) {
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
+    let config = Config::default().set_baudrate(2000000.Bd());
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
+
+    writeln!(serial, "Welcome to ADC async demo!").ok();
+
+    let mut gpip = Gpip::new(
+        p.gpip,
+        Some(AdcConfig::default().set_vref(GpadcVref::V3p2)),
+        None,
+        &p.glb,
+        &p.hbn,
+    );
+
+    let efuse = Efuse::new(p.efuse);
+    gpip.adc_calibrate(&efuse, &p.hbn, None);
+
+    // Set up PLIC interrupt
+    p.plic.set_threshold(M0Machine, 0);
+    p.plic.set_priority(McuLpInterrupt::GpadcDma, 1);
+    p.plic.enable(McuLpInterrupt::GpadcDma, M0Machine);
+
+    // Create async ADC
+    let mut async_adc = AsyncAdc::new(&mut gpip, &ADC_STATE);
+
+    let channels = [
+        AdcChannels {
+            pos_ch: GpadcChannel::Channel0,
+            neg_ch: GpadcChannel::ChannelVGND,
+        },
+        AdcChannels {
+            pos_ch: GpadcChannel::Channel1,
+            neg_ch: GpadcChannel::ChannelVGND,
+        },
+        AdcChannels {
+            pos_ch: GpadcChannel::Channel2,
+            neg_ch: GpadcChannel::ChannelVGND,
+        },
+    ];
+
+    for (_i, &channel) in channels.iter().enumerate() {
+        writeln!(serial, "Converting channel {:?}...", channel.pos_ch).ok();
+
+        let mut results = [AdcResult {
+            pos_chan: None,
+            neg_chan: None,
+            value: 0,
+            millivolt: 0,
+        }; 32];
+
+        match async_adc.convert(&[channel], &p.hbn, &mut results).await {
+            Ok(count) => {
+                writeln!(serial, "Successfully converted {} samples", count).ok();
+
+                // Print first few results
+                for j in 0..core::cmp::min(count, 5) {
+                    writeln!(
+                        serial,
+                        "Channel {:?} value = 0x{:08X}, millivolt = {}mv.",
+                        results[j].pos_chan.unwrap(),
+                        results[j].value,
+                        results[j].millivolt
+                    )
+                    .ok();
+                }
+            }
+            Err(e) => {
+                writeln!(serial, "Conversion failed: {:?}", e).ok();
+            }
+        }
+
+        writeln!(serial, "Conversion attempt completed").ok();
+    }
+
+    writeln!(serial, "ADC async demo completed!").ok();
+}
+
+#[entry]
+fn main(p: Peripherals, c: Clocks) -> ! {
+    p.plic.set_threshold(M0Machine, 0);
+    let mut fut = core::pin::pin!(async_main(p, c));
+    let waker = Waker::noop();
+    let mut ctx = Context::from_waker(waker);
+
+    unsafe {
+        riscv::register::mie::set_mext();
+        riscv::register::mstatus::set_mie();
+    }
+
+    loop {
+        match fut.as_mut().poll(&mut ctx) {
+            Poll::Ready(_) => break,
+            Poll::Pending => riscv::asm::wfi(),
+        }
+    }
+
+    unsafe { riscv::register::mstatus::clear_mie() };
+    loop {
+        riscv::asm::wfi();
+    }
+}

--- a/examples/peripherals/adc-dma-demo/Cargo.toml
+++ b/examples/peripherals/adc-dma-demo/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "adc-dma-demo"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bouffalo-hal = { path = "../../../bouffalo-hal", features = ["bl808"] }
+bouffalo-rt = { path = "../../../bouffalo-rt", features = ["bl808-dsp"] }
+panic-halt = "1.0.0"
+embedded-time = "0.12.1"
+riscv = "0.13.0"
+
+[[bin]]
+name = "adc-dma-demo"
+test = false

--- a/examples/peripherals/adc-dma-demo/README.md
+++ b/examples/peripherals/adc-dma-demo/README.md
@@ -1,0 +1,16 @@
+# ADC dma demo
+
+## Build this example for `D0` core
+
+```bash
+rustup target install riscv64imac-unknown-none-elf
+cargo build --target riscv64imac-unknown-none-elf --release -p adc-dma-demo
+```
+
+Compile the binary with:
+
+```bash
+rust-objcopy --binary-architecture=riscv64 --strip-all -O binary ./target/riscv64imac-unknown-none-elf/release/adc-dma-demo ./target/riscv64imac-unknown-none-elf/release/adc-dma-demo.bin
+```
+
+Open BL Dev Cube GUI, choose `D0` group, address `0x58000000`, then flash the binary to the board.

--- a/examples/peripherals/adc-dma-demo/build.rs
+++ b/examples/peripherals/adc-dma-demo/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tbouffalo-rt.ld");
+}

--- a/examples/peripherals/adc-dma-demo/src/main.rs
+++ b/examples/peripherals/adc-dma-demo/src/main.rs
@@ -13,6 +13,9 @@ use bouffalo_rt::{Clocks, Peripherals, entry};
 use embedded_time::rate::*;
 use panic_halt as _;
 
+/// Number of initial ADC samples to skip due to invalid data
+const SKIP_INITIAL_SAMPLES: usize = 10;
+
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
     let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
@@ -98,7 +101,7 @@ fn main(p: Peripherals, c: Clocks) -> ! {
 
         gpip.adc_parse_result(value, result, &p.hbn);
 
-        for res in result.iter().skip(10) {
+        for res in result.iter().skip(SKIP_INITIAL_SAMPLES) {
             writeln!(
                 serial,
                 "Channel {:?} value = 0x{:08X}, millivolt = {}mv.",
@@ -108,17 +111,7 @@ fn main(p: Peripherals, c: Clocks) -> ! {
             )
             .ok();
         }
-
-        delay(100);
     }
 
     loop {}
-}
-
-pub fn delay(tim: u32) {
-    unsafe {
-        for _ in 0..tim * 100 {
-            core::arch::asm!("nop");
-        }
-    }
 }

--- a/examples/peripherals/adc-dma-demo/src/main.rs
+++ b/examples/peripherals/adc-dma-demo/src/main.rs
@@ -1,0 +1,124 @@
+#![no_std]
+#![no_main]
+
+use bouffalo_hal::{
+    dma::*,
+    efuse::Efuse,
+    gpip::{AdcChannels, AdcCommand, AdcConfig, AdcResult, Gpip},
+    hbn::{GpadcChannel, GpadcVref},
+    prelude::*,
+    uart::Config,
+};
+use bouffalo_rt::{Clocks, Peripherals, entry};
+use embedded_time::rate::*;
+use panic_halt as _;
+
+#[entry]
+fn main(p: Peripherals, c: Clocks) -> ! {
+    let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
+    let rx = p.uart_muxes.sig3.into_receive(p.gpio.io15);
+    let config = Config::default().set_baudrate(2000000.Bd());
+    let mut serial = p.uart0.freerun(config, (tx, rx), &c).unwrap();
+
+    writeln!(serial, "Welcome to ADC dma demo!").ok();
+
+    let rx_config = Mem2MemChannelConfig {
+        direction: DmaMode::Mem2Mem,
+        src_addr_inc: true,
+        dst_addr_inc: true,
+        src_burst_size: BurstSize::INCR1,
+        dst_burst_size: BurstSize::INCR1,
+        src_transfer_width: TransferWidth::Word,
+        dst_transfer_width: TransferWidth::Word,
+    };
+
+    let dma0 = p.dma0.split(&p.glb);
+    let mut dma0_ch0 = dma0.ch0;
+    dma0_ch0.memory_to_memory(rx_config);
+
+    let mut gpip = Gpip::new(
+        p.gpip,
+        Some(AdcConfig::default().set_vref(GpadcVref::V3p2)),
+        None,
+        &p.glb,
+        &p.hbn,
+    );
+
+    let efuse = Efuse::new(p.efuse);
+    gpip.adc_calibrate(&efuse, &p.hbn, None);
+
+    let chans = [
+        AdcChannels {
+            pos_ch: GpadcChannel::Channel4,
+            neg_ch: GpadcChannel::ChannelVGND,
+        },
+        AdcChannels {
+            pos_ch: GpadcChannel::Channel5,
+            neg_ch: GpadcChannel::ChannelVGND,
+        },
+        AdcChannels {
+            pos_ch: GpadcChannel::Channel6,
+            neg_ch: GpadcChannel::ChannelVGND,
+        },
+    ];
+
+    for chan in chans {
+        gpip.adc_feature_control(AdcCommand::ClearFifo, false, &p.hbn);
+        gpip.adc_channel_config(&[chan], &p.hbn);
+        gpip.adc_start_conversion(&p.hbn);
+
+        let value = &mut [0u32; 16];
+
+        for i in 0..16 {
+            let rx_lli_pool = &mut [LliPool::new(); 1];
+            let val = &mut [0u32; 1];
+            let rx_transfer = &mut [LliTransfer {
+                src_addr: DmaAddr::AdcRx as u32,
+                dst_addr: val.as_mut_ptr() as u32,
+                nbytes: 4,
+            }];
+
+            dma0_ch0.lli_reload(rx_lli_pool, 1, rx_transfer, 1);
+            dma0_ch0.start();
+
+            while gpip.adc_get_complete_num() == 0 {
+                core::hint::spin_loop();
+            }
+
+            dma0_ch0.stop();
+            value[i] = val[0];
+        }
+
+        let result = &mut [AdcResult {
+            pos_chan: Some(chan.pos_ch),
+            neg_chan: Some(chan.neg_ch),
+            value: 0,
+            millivolt: 0,
+        }; 16];
+
+        gpip.adc_parse_result(value, result, &p.hbn);
+
+        for res in result.iter().skip(10) {
+            writeln!(
+                serial,
+                "Channel {:?} value = 0x{:08X}, millivolt = {}mv.",
+                res.pos_chan.unwrap(),
+                res.value,
+                res.millivolt
+            )
+            .ok();
+        }
+
+        delay(100);
+    }
+
+    loop {}
+}
+
+pub fn delay(tim: u32) {
+    unsafe {
+        for _ in 0..tim * 100 {
+            core::arch::asm!("nop");
+        }
+    }
+}

--- a/examples/peripherals/adc-poll-demo/src/main.rs
+++ b/examples/peripherals/adc-poll-demo/src/main.rs
@@ -12,6 +12,9 @@ use bouffalo_rt::{Clocks, Peripherals, entry};
 use embedded_time::rate::*;
 use panic_halt as _;
 
+/// Number of initial ADC samples to skip due to invalid data
+const SKIP_INITIAL_SAMPLES: usize = 10;
+
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
     let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
@@ -82,7 +85,7 @@ fn main(p: Peripherals, c: Clocks) -> ! {
 
         gpip.adc_parse_result(value, result, &p.hbn);
 
-        for res in result.iter().skip(10) {
+        for res in result.iter().skip(SKIP_INITIAL_SAMPLES) {
             writeln!(
                 serial,
                 "Channel {:?} value = 0x{:08X}, millivolt = {}mv.",

--- a/examples/peripherals/adc-poll-onechan-demo/src/main.rs
+++ b/examples/peripherals/adc-poll-onechan-demo/src/main.rs
@@ -12,6 +12,9 @@ use bouffalo_rt::{Clocks, Peripherals, entry};
 use embedded_time::rate::*;
 use panic_halt as _;
 
+/// Number of initial ADC samples to discard due to invalid data
+const INITIAL_SAMPLES_TO_DISCARD: usize = 10;
+
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
     let tx = p.uart_muxes.sig2.into_transmit(p.gpio.io14);
@@ -46,10 +49,10 @@ fn main(p: Peripherals, c: Clocks) -> ! {
             core::hint::spin_loop();
         }
 
-        if i > 9 {
+        if i >= INITIAL_SAMPLES_TO_DISCARD {
             raw_data += gpip.adc_get_raw_data();
         } else {
-            // Discard initial 10 samples
+            // Discard initial samples due to invalid data
             let _ = gpip.adc_get_raw_data();
         }
     }

--- a/examples/peripherals/uart-async-demo/src/main.rs
+++ b/examples/peripherals/uart-async-demo/src/main.rs
@@ -9,6 +9,7 @@ use bouffalo_rt::{
     Clocks, Peripherals, entry, interrupt,
     soc::bl808::{D0Machine, DspInterrupt},
 };
+use core::sync::atomic::{AtomicBool, Ordering};
 use embedded_time::rate::*;
 use panic_halt as _;
 
@@ -44,9 +45,23 @@ Suspendisse potenti. Nam bibendum, velit quis ullamcorper blandit, nunc odio ult
 
 static UART3_STATE: SerialState = SerialState::new();
 
+/// TASK_WAKE_FLAG is used to synchronize between the UART3 interrupt handler and the main async task.
+///
+/// - The interrupt handler sets this flag to `true` when an interrupt occurs, indicating that the main task should wake up and poll the future again.
+/// - The main task checks this flag in its loop; if set, it clears the flag and continues polling without sleeping.
+/// - This mechanism ensures that the main task responds promptly to UART events signaled by the interrupt.
+///
+/// This flag is essential for proper async operation because:
+/// 1. Without it, the main task would use `Waker::noop()` which never wakes the task
+/// 2. The task would sleep indefinitely with `wfi()` waiting for interrupts
+/// 3. When interrupts occur, this flag bridges the gap between hardware events and software task scheduling
+static TASK_WAKE_FLAG: AtomicBool = AtomicBool::new(false);
+
 #[interrupt]
 fn uart3() {
     UART3_STATE.on_interrupt();
+    // Wake the main task after handling interrupt
+    TASK_WAKE_FLAG.store(true, Ordering::Release);
 }
 
 // ---- Async/await runtime environment ----
@@ -55,12 +70,27 @@ fn uart3() {
 fn main(p: Peripherals, c: Clocks) -> ! {
     use core::{
         future::Future,
-        task::{Context, Poll, Waker},
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
     };
     p.plic.set_threshold(D0Machine, 0);
     let mut fut = core::pin::pin!(async_main(p, c));
-    let waker = Waker::noop();
-    let mut ctx = Context::from_waker(waker);
+
+    // Create a simple waker that sets a flag when called
+    unsafe fn wake_fn(_: *const ()) {
+        TASK_WAKE_FLAG.store(true, Ordering::Release);
+    }
+
+    unsafe fn clone_fn(data: *const ()) -> RawWaker {
+        RawWaker::new(data, &VTABLE)
+    }
+
+    unsafe fn noop(_: *const ()) {}
+
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone_fn, wake_fn, wake_fn, noop);
+
+    let raw_waker = RawWaker::new(core::ptr::null(), &VTABLE);
+    let waker = unsafe { Waker::from_raw(raw_waker) };
+    let mut ctx = Context::from_waker(&waker);
     unsafe {
         riscv::register::mie::set_mext();
         riscv::register::mstatus::set_mie();
@@ -68,7 +98,14 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     loop {
         match fut.as_mut().poll(&mut ctx) {
             Poll::Ready(_) => break,
-            Poll::Pending => riscv::asm::wfi(),
+            Poll::Pending => {
+                // Check if we were woken up before going to sleep
+                if TASK_WAKE_FLAG.load(Ordering::Acquire) {
+                    TASK_WAKE_FLAG.store(false, Ordering::Release);
+                    continue; // Don't sleep, poll again
+                }
+                riscv::asm::wfi();
+            }
         }
     }
     unsafe { riscv::register::mstatus::clear_mie() };


### PR DESCRIPTION
- Add interrupt support for bl808 m0 and lp core.
- Add new example `adc-dma-demo`, `adc-async-demo`.
adc-async-demo
<img width="1618" height="1014" alt="微信图片_20250916185808_31_121" src="https://github.com/user-attachments/assets/da0025c1-3927-4cf2-a945-9a596544bcb3" />
adc-dma-demo
<img width="791" height="507" alt="微信图片_20250916192615_32_121" src="https://github.com/user-attachments/assets/79847d1c-2de4-42f9-af3e-8119d87a800b" />

- Add opening uart console support , running on default config and more interactive console for blri.
  - We can use the following command to run project and open uart:
  ```bash
  # Normal output mode
  cargo run --target riscv64imac-unknown-none-elf --release -p uart-demo -- --reset
  # Console mode
  cargo run --target riscv64imac-unknown-none-elf --release -p uart-demo -- --reset --console
  # Run with default config automatically saved in ./target/settings.toml
  cargo blri-default
  ```
  
  https://github.com/user-attachments/assets/26a2010c-a70e-4b0e-8961-fc666daa5c3b
  
- Update README for blri.

